### PR TITLE
Agregar soporte para tipo de producto '.7 y .3' en cálculo de kilos

### DIFF
--- a/src/views/Procesos/PedidoLimpioImpresion.vue
+++ b/src/views/Procesos/PedidoLimpioImpresion.vue
@@ -660,6 +660,7 @@ export default {
       let kilosSinH2O = 0;
       let kilosConH2O = 0;
       let kilosTaras = 0;
+      let kilos7y3 = 0;
 
       this.clientesTemporales[clienteId].forEach(item => {
         if (item.kilos) {
@@ -674,6 +675,8 @@ export default {
             kilosSinH2O += Number(item.kilos);
           } else if (item.tipo === 'C/H20') {
             kilosConH2O += Number(item.kilos);
+          } else if (item.tipo === '.7 y .3') {
+            kilos7y3 += Number(item.kilos) * 0.7;
           }
         }
       });
@@ -681,7 +684,7 @@ export default {
       const tarasPorKilos = kilosSinH2O / 27;
       const tarasTotal = Math.round(tarasDirectas + tarasPorKilos);
       const totalKilosSinH2O = kilosSinH2O + kilosTaras;
-      const kilosTotal = Math.round(totalKilosSinH2O + kilosConH2O);
+      const kilosTotal = Math.round(totalKilosSinH2O + kilosConH2O + kilos7y3);
 
       return {
         tarasTotal: tarasTotal.toString(),
@@ -726,6 +729,8 @@ export default {
               registro.total += kilos * 0.65; // Kilos con agua
             } else if (item.tipo === '1.35 y .15') {
               registro.total += kilos * 1.35; // Kilos con factor 1.35
+            } else if (esPedidoOzuna && item.tipo === '.7 y .3') {
+              registro.total += kilos * 0.7; // Para Ozuna, kilos con factor 0.7
             } else {
               registro.total += kilos; // Kilos normales
             }

--- a/src/views/Procesos/PedidosLimpio.vue
+++ b/src/views/Procesos/PedidosLimpio.vue
@@ -372,6 +372,7 @@
                     <option value="">Seleccionar</option>
                     <option value="S/H20">S/H20</option>
                     <option value="C/H20" class="text-blue">C/H20</option>
+                    <option value=".7 y .3">.7 y .3</option>
                   </select>
                 </div>
 
@@ -748,6 +749,7 @@ export default {
       let kilosSinH2O = 0;
       let kilosConH2O = 0;
       let kilosTaras = 0;
+      let kilos7y3 = 0;
 
       this.pedidoOzuna.forEach(item => {
         if (item.kilos) {
@@ -762,6 +764,8 @@ export default {
             kilosSinH2O += Number(item.kilos);
           } else if (item.tipo === 'C/H20') {
             kilosConH2O += Number(item.kilos);
+          } else if (item.tipo === '.7 y .3') {
+            kilos7y3 += Number(item.kilos) * 0.7;
           }
         }
       });
@@ -769,7 +773,7 @@ export default {
       const tarasPorKilos = kilosSinH2O / 27;
       const tarasTotal = Math.round(tarasDirectas + tarasPorKilos);
       const totalKilosSinH2O = kilosSinH2O + kilosTaras;
-      const kilosTotal = Math.round(totalKilosSinH2O + kilosConH2O);
+      const kilosTotal = Math.round(totalKilosSinH2O + kilosConH2O + kilos7y3);
 
       return {
         tarasDirectas: tarasDirectas.toFixed(2),
@@ -777,6 +781,7 @@ export default {
         tarasTotal: tarasTotal.toString(),
         kilosSinH2O: Math.round(totalKilosSinH2O).toString(),
         kilosConH2O: kilosConH2O.toFixed(2),
+        kilos7y3: kilos7y3.toFixed(2),
         kilosTotal: kilosTotal.toString()
       };
     },

--- a/src/views/Procesos/PedidosMenu.vue
+++ b/src/views/Procesos/PedidosMenu.vue
@@ -220,6 +220,7 @@ export default {
       let kilosTaras = 0;
       let kilos135 = 0;
       let kilosTaras135 = 0;
+      let kilos7y3 = 0;
 
       items.forEach(item => {
         if (item.kilos) {
@@ -237,11 +238,13 @@ export default {
             kilosConH2O += Number(item.kilos);
           } else if (item.tipo === '1.35 y .15') {
             kilos135 += Number(item.kilos) * 1.35;
+          } else if (item.tipo === '.7 y .3') {
+            kilos7y3 += Number(item.kilos) * 0.7;
           }
         }
       });
 
-      return kilosSinH2O + kilosTaras + kilosTaras135 + kilosConH2O + kilos135;
+      return kilosSinH2O + kilosTaras + kilosTaras135 + kilosConH2O + kilos135 + kilos7y3;
     },
     calcularTarasCliente(items) {
       let tarasDirectas = 0;


### PR DESCRIPTION
- Introducir nueva opción de tipo de producto '.7 y .3' en menús desplegables
- Implementar cálculo de kilos con factor 0.7 para el nuevo tipo de producto
- Actualizar lógica de cálculo de kilos totales en PedidosLimpio, PedidoLimpioImpresion y PedidosMenu
- Añadir opción de tipo de producto en vistas de pedidos con estilo de texto azul