### PR TITLE
Ocultar tabla de costos por defecto con botón para mostrar/ocultar

### DIFF
--- a/src/views/CuentasClientes/CuentaCliente.vue
+++ b/src/views/CuentasClientes/CuentaCliente.vue
@@ -59,7 +59,13 @@
       </div>
     </div>
 
-    <div class="table-card table-responsive">
+    <div class="toggle-costos-row">
+      <button class="toggle-costos-btn" @click="mostrarTablaCostos = !mostrarTablaCostos">
+        {{ mostrarTablaCostos ? 'Ocultar tabla de costos' : 'Mostrar tabla de costos' }}
+      </button>
+    </div>
+
+    <div v-if="mostrarTablaCostos" class="table-card table-responsive">
       <table class="tabla-principal">
         <thead>
           <tr>
@@ -471,6 +477,7 @@ export default {
       accionPendiente: null,
       // Otilio features
       isSavingVerificacion: false,
+      mostrarTablaCostos: false,
     };
   },
   computed: {
@@ -1696,6 +1703,9 @@ th { background-color: #4CAF50; color: white; position: sticky; top: 0; z-index:
 .guardar-container { margin-bottom: 20px; }
 .observacion-container { margin-bottom: 10px; }
 .btn-agregar-observacion { background-color: #607d8b; padding: 8px 16px; font-size: 14px; }
+.toggle-costos-row { margin-bottom: 12px; display: flex; justify-content: flex-end; }
+.toggle-costos-btn { background-color: #607d8b; padding: 8px 16px; font-size: 14px; }
+.toggle-costos-btn:hover { background-color: #546e7a; }
 .observacion-existente { background-color: #fff3e0; border-left: 4px solid #ff9800; padding: 12px; border-radius: 4px; margin-top: 10px; }
 .observacion-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 8px; }
 .observacion-titulo { font-weight: bold; margin: 0; }


### PR DESCRIPTION
## Resumen
- La tabla de costos en las cuentas de clientes ahora está oculta por defecto.
- Se agregó un botón "Mostrar/Ocultar tabla de costos" para alternar su visibilidad.
- Aplica a todos los clientes (componente compartido `CuentaCliente.vue`).

## Test plan
- [ ] Abrir la cuenta de cualquier cliente y verificar que la tabla de costos no se muestra inicialmente.
- [ ] Hacer clic en "Mostrar tabla de costos" y verificar que aparece la tabla con sus datos.
- [ ] Hacer clic en "Ocultar tabla de costos" y verificar que se oculta nuevamente.
- [ ] Confirmar que el resto de la página (precios de venta, fletes, abonos, etc.) sigue funcionando con normalidad.

https://claude.ai/code/session_01FeqzSRSPKJSZ4dzxRm4SrU

---
_Generated by [Claude Code](https://claude.ai/code/session_01FeqzSRSPKJSZ4dzxRm4SrU)_