### PR TITLE
Evitar que la sincronización borre las marcas de pago de fletes

### DIFF
--- a/src/views/Embarques/CuentaFletes.vue
+++ b/src/views/Embarques/CuentaFletes.vue
@@ -124,6 +124,7 @@ import {
   filtrarFletesPorChofer,
   normalizarTexto,
   obtenerClaveChoferPago,
+  obtenerFechaISO,
   obtenerTotalTaras,
   ordenarMovimientos,
   transformarEmbarqueAFlete
@@ -300,10 +301,7 @@ export default {
       return this.formatoMoneda.format(Number(monto) || 0);
     },
     obtenerClaveFechaMovimiento(fecha) {
-      if (!fecha) return '';
-      const fechaObj = fecha instanceof Date ? fecha : new Date(fecha);
-      if (Number.isNaN(fechaObj.getTime())) return '';
-      return fechaObj.toISOString().split('T')[0];
+      return obtenerFechaISO(fecha);
     },
     cambiarChofer(chofer) {
       this.choferSeleccionado = chofer;

--- a/src/views/Embarques/components/CuentaFletes/cuentaFletesUtils.js
+++ b/src/views/Embarques/components/CuentaFletes/cuentaFletesUtils.js
@@ -1,3 +1,5 @@
+import { normalizarFechaValor } from '@/utils/dateUtils';
+
 export const COSTO_TARA_LIMPIO = 70;
 export const COSTO_TARA_CRUDO = 60;
 export const COSTO_TARA_LIMPIO_NUEVO = 100;
@@ -56,10 +58,10 @@ export function esCargaDeUnSoloChofer(cargaCon, chofer) {
 }
 
 export function obtenerFechaISO(fecha) {
-  if (!fecha) return '';
-  const fechaObj = fecha instanceof Date ? fecha : new Date(fecha);
-  if (Number.isNaN(fechaObj.getTime())) return '';
-  return fechaObj.toISOString().split('T')[0];
+  // Normalización canónica: strings ISO se recortan sin pasar por zona
+  // horaria (toISOString clasificaba capturas de tarde-noche en el día
+  // siguiente UTC) y una fecha corrupta regresa '' en vez de lanzar.
+  return normalizarFechaValor(fecha) || '';
 }
 
 export function calcularTarasProductos(productos = []) {

--- a/src/views/Embarques/mixins/embarqueSyncMixin.js
+++ b/src/views/Embarques/mixins/embarqueSyncMixin.js
@@ -69,11 +69,36 @@ export function normalizarDocDataParaFirestore(docData, record = {}, contexto = 
     fecha: parseFecha(dataCruda.fecha || record.fecha || contexto.fechaDefault),
   };
 
-  // Campos escritos por otras vistas (p. ej. Rendimientos) o flujos:
-  // conservarlos si existen local o remotamente para no borrarlos al
-  // reescribir el documento completo con setDoc.
-  ['totalGanancias', 'rendimientoManual', 'borrador'].forEach((key) => {
+  // Campos del flujo del editor: conservarlos si existen local o remotamente
+  // para no borrarlos al reescribir el documento completo con setDoc.
+  ['borrador'].forEach((key) => {
     const valor = pickConRemoto(key);
+    if (valor !== undefined) {
+      data[key] = valor;
+    }
+  });
+
+  // Campos que otras vistas escriben DIRECTO en Firestore sin pasar por el
+  // espejo offline: Rendimientos (totalGanancias, rendimientoManual) y Cuenta
+  // de Fletes (fletePagado, fletePagos, fletePagoActualizado*). Para estos, el
+  // valor remoto SIEMPRE es el más fresco — el espejo offline puede traer una
+  // copia vieja que revertiría pagos de fletes ya marcados. Preferir
+  // remoto → snapshot local → record; omitirlos borraba las marcas de pago en
+  // cada sincronización y los fletes viejos volvían a aparecer "pendientes".
+  const pickPreferRemoto = (key) => {
+    const remoto = contexto.dataRemota;
+    if (remoto && remoto[key] !== undefined && remoto[key] !== null) return remoto[key];
+    return pickConRemoto(key);
+  };
+  [
+    'totalGanancias',
+    'rendimientoManual',
+    'fletePagado',
+    'fletePagos',
+    'fletePagoActualizadoEn',
+    'fletePagoActualizadoPor'
+  ].forEach((key) => {
+    const valor = pickPreferRemoto(key);
     if (valor !== undefined) {
       data[key] = valor;
     }


### PR DESCRIPTION
## Resumen

Los fletes ya pagados volvían a aparecer como **pendientes** en Cuenta de Fletes después de un tiempo, arruinando la consistencia de las cuentas.

## Causa raíz

El estado de pago vive en el documento del embarque (`fletePagado`, `fletePagos.{chofer}`), escrito directo a Firestore por Cuenta de Fletes. Pero `normalizarDocDataParaFirestore` — la lista de campos con la que la sincronización offline **reescribe el documento completo** con `setDoc(merge:false)` — no incluía esos campos. Cada sync de un embarque con cambios pendientes borraba las marcas de pago, y el flete reaparecía como pendiente.

## Cambios

- `fletePagado`, `fletePagos`, `fletePagoActualizadoEn/Por` se conservan en toda reescritura, prefiriendo el valor **remoto** sobre el espejo offline (Cuenta de Fletes escribe directo a Firestore, así que la copia offline puede estar vieja y habría revertido pagos igualmente).
- Mismo tratamiento remote-first para `totalGanancias` y `rendimientoManual` (Rendimientos los escribe con el mismo patrón).
- La agrupación por fecha del módulo de fletes usa la normalización canónica `normalizarFechaValor` en vez de `toISOString` (que clasificaba capturas de tarde-noche en el día siguiente UTC).

## Verificación

- 8 escenarios probados contra la función real compilada: marcas solo-remotas sobreviven al `setDoc`; el remoto fresco gana sobre el espejo viejo; sin remoto se usa lo local; sin marcas no se cuelan `undefined` al payload; `noEnviadoMexico` conserva su semántica local-first (tiene flujo offline propio).
- `npm run build:web` pasa completo.

## Nota

Las marcas ya borradas no son recuperables (el dato fue destruido); los fletes afectados deben re-marcarse como pagados una última vez — con este fix ya no se revierten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CFmXhJcButeUhZG6sx7Kk2

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFmXhJcButeUhZG6sx7Kk2)_