### PR TITLE
Cerrar el submenu de Existencias al elegir opción o hacer click fuera

### DIFF
--- a/src/NavBar.vue
+++ b/src/NavBar.vue
@@ -106,7 +106,7 @@
             <span class="thermal-indicator"></span>
           </router-link>
 
-          <details class="desktop-more-menu desktop-exist-menu">
+          <details class="desktop-more-menu desktop-exist-menu" ref="existDetails">
             <summary class="nav-link nav-link-more" aria-label="Ver existencias">
               <span class="link-bracket">⟨</span>
               <span class="link-index">05</span>
@@ -114,10 +114,10 @@
               <span class="link-bracket">⟩</span>
             </summary>
             <div class="desktop-more-panel">
-              <router-link 
-                to="/existencias" 
+              <router-link
+                to="/existencias"
                 class="nav-link"
-                @click="closeMobileMenu"
+                @click.native="closeMobileMenu(); closeExistMenu()"
                 aria-label="Ver existencias de limpios"
               >
                 <span class="link-bracket">⟨</span>
@@ -125,10 +125,10 @@
                 <span class="link-bracket">⟩</span>
                 <span class="thermal-indicator"></span>
               </router-link>
-              <router-link 
-                to="/existencias-crudos" 
+              <router-link
+                to="/existencias-crudos"
                 class="nav-link"
-                @click="closeMobileMenu"
+                @click.native="closeMobileMenu(); closeExistMenu()"
                 aria-label="Ver existencias de crudos"
               >
                 <span class="link-bracket">⟨</span>
@@ -321,13 +321,25 @@ export default {
       if (window.innerWidth > 1024 && this.mobileMenuOpen) {
         this.closeMobileMenu();
       }
+    },
+    closeExistMenu() {
+      const details = this.$refs.existDetails;
+      if (details) details.open = false;
+    },
+    handleClickOutsideExistMenu(event) {
+      const details = this.$refs.existDetails;
+      if (details && details.open && !details.contains(event.target)) {
+        details.open = false;
+      }
     }
   },
   mounted() {
     window.addEventListener('resize', this.handleResize);
+    document.addEventListener('click', this.handleClickOutsideExistMenu);
   },
   beforeDestroy() {
     window.removeEventListener('resize', this.handleResize);
+    document.removeEventListener('click', this.handleClickOutsideExistMenu);
     // Ensure body scroll is restored
     document.body.style.overflow = '';
     document.body.classList.remove('mobile-menu-open');


### PR DESCRIPTION
## Resumen

El submenú `EXIST > LIMPIOS/CRUDOS` de la barra de navegación se quedaba abierto después de seleccionar una opción o de hacer click en cualquier otro lugar de la página.

## Causa raíz

El submenú usa un elemento `<details>/<summary>` nativo del HTML, que no se cierra solo al navegar (SPA) ni al hacer click fuera — requiere cerrarse explícitamente. El código ya intentaba hacerlo con `@click="closeMobileMenu"` en los links, pero `<router-link>` es un componente de Vue: un `@click` sin el modificador `.native` se trata como evento personalizado (solo se dispara vía `$emit`), y `RouterLink` nunca emite `'click'` — por eso el cierre nunca se ejecutaba con un clic real de usuario, aunque la navegación sí funcionaba.

## Cambios

- Cierre explícito del `<details>` al seleccionar "Limpios" o "Crudos" (`closeExistMenu`).
- Listener de `click` en `document` que cierra el submenú si el click ocurre fuera de él.
- `.native` agregado a los `@click` de esos dos links para que el handler realmente se ejecute.

## Verificación

- Probado con Playwright contra el dev server: abrir → click fuera → cierra; reabrir → click en "Limpios" → navega y cierra. Capturas de pantalla confirmando el comportamiento en los tres escenarios.
- `npm run build:web` pasa completo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CFmXhJcButeUhZG6sx7Kk2

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFmXhJcButeUhZG6sx7Kk2)_