### PR TITLE
Edición colaborativa en tiempo real de embarques entre dos personas

### DIFF
--- a/src/utils/embarqueContenido.js
+++ b/src/utils/embarqueContenido.js
@@ -15,6 +15,24 @@ const arrayHasPositiveNumber = (arr) => {
 const stringHasContent = (value) => typeof value === 'string' && value.trim().length > 0;
 
 /**
+ * Serialización estable (llaves ordenadas recursivamente) para comparar
+ * objetos que dieron una vuelta por Firestore, donde el orden de llaves no
+ * está garantizado. `undefined` se trata como null.
+ */
+export function serializarEstable(valor) {
+  if (valor === undefined || valor === null) return 'null';
+  if (Array.isArray(valor)) {
+    return '[' + valor.map(serializarEstable).join(',') + ']';
+  }
+  if (typeof valor === 'object') {
+    return '{' + Object.keys(valor).sort()
+      .map((k) => JSON.stringify(k) + ':' + serializarEstable(valor[k]))
+      .join(',') + '}';
+  }
+  return JSON.stringify(valor);
+}
+
+/**
  * Determina si un producto individual tiene información capturada
  * (medida, precio, kilos, taras o reportes). Un producto sin nada de esto es
  * un renglón placeholder: cada editor crea el suyo automáticamente, así que

--- a/src/utils/embarqueContenido.js
+++ b/src/utils/embarqueContenido.js
@@ -33,6 +33,33 @@ export function serializarEstable(valor) {
 }
 
 /**
+ * Fusión de 3 vías CAMPO POR CAMPO de un producto editado por dos personas a
+ * la vez: cada campo se compara contra la última versión sincronizada (base).
+ * El campo que cambió localmente conserva el valor local (incluye borrados de
+ * campo); el que cambió solo en remoto toma el remoto. Si ambos cambiaron el
+ * mismo campo gana el local — converge porque el otro lado hace la elección
+ * espejo y el último en subir define el valor final.
+ */
+export function fusionarProductoTresVias(base, local, remoto) {
+  const resultado = {};
+  const llaves = new Set([
+    ...Object.keys(remoto || {}),
+    ...Object.keys(local || {})
+  ]);
+  llaves.forEach((llave) => {
+    const sBase = serializarEstable(base ? base[llave] : undefined);
+    const vLocal = local ? local[llave] : undefined;
+    const vRemoto = remoto ? remoto[llave] : undefined;
+    const localCambio = serializarEstable(vLocal) !== sBase;
+    const valor = localCambio ? vLocal : vRemoto;
+    if (valor !== undefined) {
+      resultado[llave] = valor;
+    }
+  });
+  return resultado;
+}
+
+/**
  * Determina si un producto individual tiene información capturada
  * (medida, precio, kilos, taras o reportes). Un producto sin nada de esto es
  * un renglón placeholder: cada editor crea el suyo automáticamente, así que

--- a/src/utils/embarqueContenido.js
+++ b/src/utils/embarqueContenido.js
@@ -15,6 +15,27 @@ const arrayHasPositiveNumber = (arr) => {
 const stringHasContent = (value) => typeof value === 'string' && value.trim().length > 0;
 
 /**
+ * Determina si un producto individual tiene información capturada
+ * (medida, precio, kilos, taras o reportes). Un producto sin nada de esto es
+ * un renglón placeholder: cada editor crea el suyo automáticamente, así que
+ * al fusionar ediciones colaborativas los placeholders ajenos se descartan
+ * para no duplicar renglones vacíos.
+ */
+export function productoTieneContenido(producto) {
+  if (!producto) return false;
+  return (
+    stringHasContent(producto.medida) ||
+    stringHasContent(producto.nombreAlternativoPDF) ||
+    toNumber(producto.precio) > 0 ||
+    arrayHasPositiveNumber(producto.kilos) ||
+    arrayHasPositiveNumber(producto.taras) ||
+    arrayHasPositiveNumber(producto.tarasExtra) ||
+    arrayHasPositiveNumber(producto.reporteTaras) ||
+    arrayHasPositiveNumber(producto.reporteBolsas)
+  );
+}
+
+/**
  * Determina si un embarque (docData) tiene datos operativos reales.
  *
  * Importante: NO considera como "contenido" el simple hecho de que existan

--- a/src/views/Embarques/NuevoEmbarque.vue
+++ b/src/views/Embarques/NuevoEmbarque.vue
@@ -840,8 +840,12 @@ export default {
       if (this.productosNuevosPendientes && this.productosNuevosPendientes.size > 0) {
         this.productosNuevosPendientes.forEach((producto, id) => {
           const existeEnServidor = productosServidor.some(p => p.id === id);
-          if (!existeEnServidor && !esPlaceholderRedundante(producto) && !eliminadosRemotos[id]) {
-            productosNuevosAPreservar.push(producto);
+          // Preservar la versión local VIVA (lo que se está tecleando), no la
+          // copia tomada al crear el producto: la copia vieja pisaba lo escrito.
+          const productoVivo = productosLocales.find(p => p.id === id) || producto;
+          if (!existeEnServidor && !esPlaceholderRedundante(productoVivo) && !eliminadosRemotos[id]) {
+            productosNuevosAPreservar.push(productoVivo);
+            this.productosNuevosPendientes.set(id, { ...productoVivo });
           } else {
             this.productosNuevosPendientes.delete(id);
           }

--- a/src/views/Embarques/NuevoEmbarque.vue
+++ b/src/views/Embarques/NuevoEmbarque.vue
@@ -1044,13 +1044,7 @@ export default {
 
     eliminarProducto(producto) {
       console.log(`[ELIMINAR-PRODUCTO] Intentando eliminar: ID: ${producto.id}, Medida: ${producto.medida}, Cliente: ${this.obtenerNombreCliente(producto.clienteId)}`);
-      
-      // Marcar el producto como eliminado localmente para evitar que se restaure
-      if (!this.productosEliminadosLocalmente) {
-        this.productosEliminadosLocalmente = new Set();
-      }
-      this.productosEliminadosLocalmente.add(producto.id);
-      
+
       // Marcar el cliente como modificado inmediatamente
       this.$set(this.clientesModificados, producto.clienteId, true);
       
@@ -1122,24 +1116,54 @@ export default {
     
     _eliminarProductoPorIndice(index, metodo) {
       const producto = this.embarque.productos[index];
-      
+
       console.log(`[ELIMINAR-PRODUCTO] 🗑️  Eliminando producto (${metodo}):`, {
         indice: index,
         id: producto.id,
         medida: producto.medida,
         clienteId: producto.clienteId
       });
-      
+
+      // Marcar como eliminado localmente SOLO cuando el borrado realmente
+      // procede (si se registrara antes y el borrado se abortara, la lápida
+      // se subiría igual y borraría el producto de todos modos).
+      if (!this.productosEliminadosLocalmente) {
+        this.productosEliminadosLocalmente = new Set();
+      }
+      this.productosEliminadosLocalmente.add(producto.id);
+
       // Eliminar el producto del array
       this.embarque.productos.splice(index, 1);
-      
+
       console.log(`[ELIMINAR-PRODUCTO] ✅ Producto eliminado exitosamente. Productos restantes: ${this.embarque.productos.length}`);
+
+      // Publicar la lápida DE INMEDIATO con un update puntual: si otro editor
+      // está tecleando, la subida completa puede perder la carrera de
+      // revisiones una y otra vez, pero este update pequeño entra igual y la
+      // fusión del otro lado respeta la lápida (el borrado no se pierde).
+      if (this.embarqueId && navigator.onLine) {
+        const db = getFirestore();
+        const marcaLapida = Date.now();
+        const revNueva = (Number(this._revBase) || 0) + 1;
+        updateDoc(doc(db, "embarques", this.embarqueId), {
+          [`productosEliminados.${producto.id}`]: marcaLapida,
+          rev: revNueva
+        }).then(() => {
+          this._revBase = revNueva;
+          this._productosEliminadosDoc = {
+            ...(this._productosEliminadosDoc || {}),
+            [producto.id]: marcaLapida
+          };
+        }).catch((error) => {
+          console.warn('[ELIMINAR-PRODUCTO] No se pudo publicar la lápida de inmediato (se subirá con el guardado normal):', error);
+        });
+      }
 
       // Guardar cambios si es necesario
       if (this.embarqueId) {
         this.guardarCambiosEnTiempoReal();
       }
-      
+
       // Actualizar las medidas usadas después de eliminar
       this.actualizarMedidasUsadas();
     },

--- a/src/views/Embarques/NuevoEmbarque.vue
+++ b/src/views/Embarques/NuevoEmbarque.vue
@@ -842,8 +842,10 @@ export default {
           const existeEnServidor = productosServidor.some(p => p.id === id);
           // Preservar la versión local VIVA (lo que se está tecleando), no la
           // copia tomada al crear el producto: la copia vieja pisaba lo escrito.
+          // Las filas creadas por el usuario se preservan aunque estén vacías;
+          // el descarte de placeholders aplica solo a renglones auto-creados.
           const productoVivo = productosLocales.find(p => p.id === id) || producto;
-          if (!existeEnServidor && !esPlaceholderRedundante(productoVivo) && !eliminadosRemotos[id]) {
+          if (!existeEnServidor && !eliminadosRemotos[id]) {
             productosNuevosAPreservar.push(productoVivo);
             this.productosNuevosPendientes.set(id, { ...productoVivo });
           } else {
@@ -1428,11 +1430,17 @@ export default {
     toggleBloqueo() {
       this.embarqueBloqueado = !this.embarqueBloqueado;
 
-      // Guardar el estado en Firebase si estamos en modo edición
+      // Guardar el estado en Firebase si estamos en modo edición.
+      // Incrementar rev: sin señal de cambio, los demás editores descartan
+      // el snapshot como eco repetido y no se enteran del bloqueo.
       if (this.modoEdicion && this.embarqueId) {
         const db = getFirestore();
+        const revNueva = (Number(this._revBase) || 0) + 1;
         updateDoc(doc(db, "embarques", this.embarqueId), {
-          embarqueBloqueado: this.embarqueBloqueado
+          embarqueBloqueado: this.embarqueBloqueado,
+          rev: revNueva
+        }).then(() => {
+          this._revBase = revNueva;
         }).catch(error => {
           console.error("Error al guardar estado de bloqueo:", error);
         });

--- a/src/views/Embarques/NuevoEmbarque.vue
+++ b/src/views/Embarques/NuevoEmbarque.vue
@@ -39,6 +39,15 @@
         @abrir-multi-notas="abrirModalNotasMultiple"
       />
 
+      <!-- Aviso de edición colaborativa: quién más está editando este embarque -->
+      <div v-if="editoresEmbarque.length > 0" class="banner-colaboracion">
+        <span class="banner-colaboracion-icono">👥</span>
+        <span>
+          También editando ahora: <strong>{{ editoresEmbarque.join(', ') }}</strong>.
+          Los cambios de ambos se sincronizan en vivo.
+        </span>
+      </div>
+
       <!-- Slider de escala para el resumen PDF -->
       <div v-if="mostrarEscalaResumen" class="scale-control scale-control-resumen">
         <label>Escala del resumen PDF:</label>
@@ -1509,6 +1518,14 @@ export default {
   },
 
   watch: {
+    embarqueId(nuevoId) {
+      // Presencia colaborativa: registrar/retirar a este usuario como editor
+      if (nuevoId) {
+        this.iniciarPresenciaEmbarque(nuevoId);
+      } else {
+        this.detenerPresenciaEmbarque();
+      }
+    },
     embarque: {
       handler(nuevoValor) {
         if (this.isUndoRedo) {
@@ -1792,6 +1809,25 @@ export default {
 </script>
 
 <style scoped>
+/* Aviso de edición colaborativa */
+.banner-colaboracion {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 8px 12px;
+  padding: 10px 14px;
+  background-color: #e8f4fd;
+  border: 1px solid #7cc0ef;
+  border-left: 4px solid #2196f3;
+  border-radius: 6px;
+  color: #0d47a1;
+  font-size: 0.95rem;
+}
+
+.banner-colaboracion-icono {
+  font-size: 1.2rem;
+}
+
 /* Estilos base */
 .nuevo-embarque-container {
   position: relative;

--- a/src/views/Embarques/NuevoEmbarque.vue
+++ b/src/views/Embarques/NuevoEmbarque.vue
@@ -286,7 +286,7 @@ import {
 } from '@/utils/dateUtils';
 import { obtenerPrecioMaquilaOzunaDefault } from '@/utils/preciosHistoricos';
 import { generarNotaVentaPDF } from '@/utils/pdfGenerator';
-import { embarqueTieneContenidoOperativoDoc, embarqueTieneContenidoOperativoEstado } from '@/utils/embarqueContenido';
+import { embarqueTieneContenidoOperativoDoc, embarqueTieneContenidoOperativoEstado, productoTieneContenido } from '@/utils/embarqueContenido';
 
 // Después de las imports existentes, agregar:
 import EmbarquesOfflineService from '@/services/EmbarquesOfflineService';
@@ -821,12 +821,22 @@ export default {
         productosFinales.push(productoMergeado);
       });
 
+      // Placeholder redundante: renglón vacío de un cliente que ya tiene
+      // productos en el servidor (cada editor crea el suyo; preservarlos
+      // duplica renglones vacíos entre colaboradores).
+      const clientesConProductosEnServidor = new Set(
+        productosServidor.map(p => String(p.clienteId))
+      );
+      const esPlaceholderRedundante = (producto) =>
+        !productoTieneContenido(producto) &&
+        clientesConProductosEnServidor.has(String(producto.clienteId));
+
       // Preservar productos nuevos pendientes de sincronización
       const productosNuevosAPreservar = [];
       if (this.productosNuevosPendientes && this.productosNuevosPendientes.size > 0) {
         this.productosNuevosPendientes.forEach((producto, id) => {
           const existeEnServidor = productosServidor.some(p => p.id === id);
-          if (!existeEnServidor) {
+          if (!existeEnServidor && !esPlaceholderRedundante(producto)) {
             productosNuevosAPreservar.push(producto);
           } else {
             this.productosNuevosPendientes.delete(id);
@@ -836,9 +846,10 @@ export default {
 
       // También preservar productos locales con UUID no sincronizados
       productosLocales.forEach(productoLocal => {
-        if (esUUIDValido(productoLocal.id) && 
+        if (esUUIDValido(productoLocal.id) &&
             !productosServidor.some(p => p.id === productoLocal.id) &&
-            !productosNuevosAPreservar.some(p => p.id === productoLocal.id)) {
+            !productosNuevosAPreservar.some(p => p.id === productoLocal.id) &&
+            !esPlaceholderRedundante(productoLocal)) {
           productosNuevosAPreservar.push(productoLocal);
           if (!this.productosNuevosPendientes.has(productoLocal.id)) {
             this.productosNuevosPendientes.set(productoLocal.id, { ...productoLocal });
@@ -1565,8 +1576,17 @@ export default {
     },
     clienteCrudos: {
       handler() {
+        // No marcar cambios pendientes cuando lo que cambió vino del servidor
+        // (aplicarDocRemoto): eso creaba un bucle de subidas sin cambios.
+        if (this._inicializandoEmbarque || this._aplicandoRemoto) {
+          return;
+        }
         // Guardar crudos en localStorage para persistencia offline
-        localStorage.setItem('clienteCrudos', JSON.stringify(this.clienteCrudos));
+        try {
+          localStorage.setItem('clienteCrudos', JSON.stringify(this.clienteCrudos));
+        } catch (error) {
+          console.warn('[watch clienteCrudos] No se pudo guardar en localStorage:', error);
+        }
         this.guardarCambiosEnTiempoReal();
       },
       deep: true
@@ -1597,6 +1617,10 @@ export default {
     },
     'embarque.cargaCon': {
       handler(newVal, oldVal) {
+        // Ignorar cambios que vienen de aplicar el documento remoto
+        if (this._inicializandoEmbarque || this._aplicandoRemoto) {
+          return;
+        }
         if (!this.embarqueId) {
           this.triggerGuardadoInicial();
         } else {

--- a/src/views/Embarques/NuevoEmbarque.vue
+++ b/src/views/Embarques/NuevoEmbarque.vue
@@ -831,12 +831,16 @@ export default {
         !productoTieneContenido(producto) &&
         clientesConProductosEnServidor.has(String(producto.clienteId));
 
+      // Lápidas de borrado: productos eliminados por algún editor no se
+      // preservan (sin esto, el borrado de la otra persona "revivía" aquí).
+      const eliminadosRemotos = this._productosEliminadosDoc || {};
+
       // Preservar productos nuevos pendientes de sincronización
       const productosNuevosAPreservar = [];
       if (this.productosNuevosPendientes && this.productosNuevosPendientes.size > 0) {
         this.productosNuevosPendientes.forEach((producto, id) => {
           const existeEnServidor = productosServidor.some(p => p.id === id);
-          if (!existeEnServidor && !esPlaceholderRedundante(producto)) {
+          if (!existeEnServidor && !esPlaceholderRedundante(producto) && !eliminadosRemotos[id]) {
             productosNuevosAPreservar.push(producto);
           } else {
             this.productosNuevosPendientes.delete(id);
@@ -849,7 +853,8 @@ export default {
         if (esUUIDValido(productoLocal.id) &&
             !productosServidor.some(p => p.id === productoLocal.id) &&
             !productosNuevosAPreservar.some(p => p.id === productoLocal.id) &&
-            !esPlaceholderRedundante(productoLocal)) {
+            !esPlaceholderRedundante(productoLocal) &&
+            !eliminadosRemotos[productoLocal.id]) {
           productosNuevosAPreservar.push(productoLocal);
           if (!this.productosNuevosPendientes.has(productoLocal.id)) {
             this.productosNuevosPendientes.set(productoLocal.id, { ...productoLocal });
@@ -978,6 +983,11 @@ export default {
       if (this.productosEliminadosLocalmente && this.productosEliminadosLocalmente.has(nuevoProducto.id)) {
         console.log('[AGREGAR-PRODUCTO] Removiendo producto de la lista de eliminados:', nuevoProducto.id);
         this.productosEliminadosLocalmente.delete(nuevoProducto.id);
+      }
+      if (this._productosEliminadosDoc && this._productosEliminadosDoc[nuevoProducto.id]) {
+        const lapidas = { ...this._productosEliminadosDoc };
+        delete lapidas[nuevoProducto.id];
+        this._productosEliminadosDoc = lapidas;
       }
 
       // Marcar el producto como nuevo pendiente de sincronización ANTES de agregarlo

--- a/src/views/Embarques/mixins/embarqueCargaMixin.js
+++ b/src/views/Embarques/mixins/embarqueCargaMixin.js
@@ -2,7 +2,7 @@ import { getFirestore, doc, onSnapshot, addDoc, collection } from 'firebase/fire
 import EmbarquesOfflineService from '@/services/EmbarquesOfflineService';
 import { normalizarFechaISO, obtenerFechaActualISO } from '@/utils/dateUtils';
 import { crearNuevoProducto } from '@/constants.js/embarque';
-import { embarqueTieneContenidoOperativoDoc, embarqueTieneContenidoOperativoEstado } from '@/utils/embarqueContenido';
+import { embarqueTieneContenidoOperativoDoc, embarqueTieneContenidoOperativoEstado, productoTieneContenido } from '@/utils/embarqueContenido';
 
 export const esUUIDValido = (id) => {
   const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -62,6 +62,17 @@ export const embarqueCargaMixin = {
 
         if (docSnapshot.exists()) {
           const data = docSnapshot.data();
+
+          // Eco de nuestra propia escritura (o snapshot repetido): si el
+          // documento trae exactamente la revisión en la que ya está basado
+          // el estado local, no hay nada nuevo que aplicar. Sin este corte,
+          // re-aplicar el eco dispara watchers y provoca un bucle de
+          // subidas/aplicaciones sin cambios reales.
+          const revRemota = Number(data.rev) || 0;
+          if (!this._inicializandoEmbarque && revRemota !== 0 &&
+              revRemota === (Number(this._revBase) || 0)) {
+            return;
+          }
 
           if (this.hasPendingChanges) {
             // Hay cambios locales sin subir: aplicar lo remoto ahora pisaría
@@ -268,17 +279,28 @@ export const embarqueCargaMixin = {
               console.log('[onSnapshot] Hay campos en edición, mergear cuidadosamente');
               productosFinales = this.mergeProductosConCamposEnEdicion(productosDesdeServidor, productosFiltrados);
             } else {
+              // Placeholder redundante: renglón vacío de un cliente que ya
+              // tiene productos en el servidor. Cada editor crea el suyo
+              // automáticamente; si se preservan, cada colaborador duplica
+              // los renglones vacíos del otro.
+              const clientesConProductosEnServidor = new Set(
+                productosDesdeServidor.map(p => String(p.clienteId))
+              );
+              const esPlaceholderRedundante = (producto) =>
+                !productoTieneContenido(producto) &&
+                clientesConProductosEnServidor.has(String(producto.clienteId));
+
               const productosNuevosAPreservar = [];
               if (this.productosNuevosPendientes && this.productosNuevosPendientes.size > 0) {
                 console.log('[onSnapshot] Preservando productos nuevos pendientes:', this.productosNuevosPendientes.size);
                 this.productosNuevosPendientes.forEach((producto, id) => {
                   const existeEnServidor = productosDesdeServidor.some(p => p.id === id);
-                  if (!existeEnServidor) {
+                  if (!existeEnServidor && !esPlaceholderRedundante(producto)) {
                     productosNuevosAPreservar.push(producto);
                     console.log('[onSnapshot] Preservando producto nuevo:', id);
                   } else {
                     this.productosNuevosPendientes.delete(id);
-                    console.log('[onSnapshot] Producto sincronizado, removiendo de pendientes:', id);
+                    console.log('[onSnapshot] Producto sincronizado o placeholder redundante, removiendo de pendientes:', id);
                   }
                 });
               }
@@ -287,7 +309,8 @@ export const embarqueCargaMixin = {
               productosLocalesActuales.forEach(productoLocal => {
                 if (esUUIDValido(productoLocal.id) &&
                     !productosDesdeServidor.some(p => p.id === productoLocal.id) &&
-                    !productosNuevosAPreservar.some(p => p.id === productoLocal.id)) {
+                    !productosNuevosAPreservar.some(p => p.id === productoLocal.id) &&
+                    !esPlaceholderRedundante(productoLocal)) {
                   console.log('[onSnapshot] Preservando producto local no sincronizado:', productoLocal.id);
                   productosNuevosAPreservar.push(productoLocal);
                   if (!this.productosNuevosPendientes.has(productoLocal.id)) {
@@ -329,7 +352,14 @@ export const embarqueCargaMixin = {
 
           } finally {
             this._inicializandoEmbarque = false;
-            this._aplicandoRemoto = false;
+            // Los watchers de Vue corren en el siguiente microtask; si esta
+            // bandera se apaga aquí (síncrono), cuando corren ya está en
+            // false y marcan los cambios remotos como cambios locales
+            // pendientes → bucle de subidas sin cambios reales. Liberarla
+            // en $nextTick garantiza que los watchers ya corrieron.
+            this.$nextTick(() => {
+              this._aplicandoRemoto = false;
+            });
           }
 
           this.guardarSnapshotOffline({ pendingSync: false, docData: data, syncState: 'synced' });

--- a/src/views/Embarques/mixins/embarqueCargaMixin.js
+++ b/src/views/Embarques/mixins/embarqueCargaMixin.js
@@ -262,10 +262,16 @@ export const embarqueCargaMixin = {
               }));
             });
 
-            let productosFiltrados = productosDesdeServidor;
+            // Lápidas de borrado del documento: productos que algún editor
+            // eliminó. Sin esto, el producto borrado por la otra persona se
+            // "preservaba" aquí como si fuera un producto nuevo local.
+            const eliminadosRemotos = data.productosEliminados || {};
+            this._productosEliminadosDoc = eliminadosRemotos;
+
+            let productosFiltrados = productosDesdeServidor.filter(p => !eliminadosRemotos[p.id]);
             if (this.productosEliminadosLocalmente && this.productosEliminadosLocalmente.size > 0) {
               console.log('[onSnapshot] Filtrando productos eliminados localmente:', this.productosEliminadosLocalmente);
-              productosFiltrados = productosDesdeServidor.filter(p =>
+              productosFiltrados = productosFiltrados.filter(p =>
                 !this.productosEliminadosLocalmente.has(p.id)
               );
             }
@@ -295,12 +301,12 @@ export const embarqueCargaMixin = {
                 console.log('[onSnapshot] Preservando productos nuevos pendientes:', this.productosNuevosPendientes.size);
                 this.productosNuevosPendientes.forEach((producto, id) => {
                   const existeEnServidor = productosDesdeServidor.some(p => p.id === id);
-                  if (!existeEnServidor && !esPlaceholderRedundante(producto)) {
+                  if (!existeEnServidor && !esPlaceholderRedundante(producto) && !eliminadosRemotos[id]) {
                     productosNuevosAPreservar.push(producto);
                     console.log('[onSnapshot] Preservando producto nuevo:', id);
                   } else {
                     this.productosNuevosPendientes.delete(id);
-                    console.log('[onSnapshot] Producto sincronizado o placeholder redundante, removiendo de pendientes:', id);
+                    console.log('[onSnapshot] Producto sincronizado, borrado o placeholder redundante, removiendo de pendientes:', id);
                   }
                 });
               }
@@ -310,7 +316,8 @@ export const embarqueCargaMixin = {
                 if (esUUIDValido(productoLocal.id) &&
                     !productosDesdeServidor.some(p => p.id === productoLocal.id) &&
                     !productosNuevosAPreservar.some(p => p.id === productoLocal.id) &&
-                    !esPlaceholderRedundante(productoLocal)) {
+                    !esPlaceholderRedundante(productoLocal) &&
+                    !eliminadosRemotos[productoLocal.id]) {
                   console.log('[onSnapshot] Preservando producto local no sincronizado:', productoLocal.id);
                   productosNuevosAPreservar.push(productoLocal);
                   if (!this.productosNuevosPendientes.has(productoLocal.id)) {

--- a/src/views/Embarques/mixins/embarqueCargaMixin.js
+++ b/src/views/Embarques/mixins/embarqueCargaMixin.js
@@ -130,6 +130,7 @@ export const embarqueCargaMixin = {
           this._aplicandoRemoto = true;
           // Revisión remota sobre la que queda basado el estado local
           // (subirCambiosEnVivo la usa para detectar conflictos).
+          const revBaseAnterior = Number(this._revBase) || 0;
           this._revBase = Number(data.rev) || 0;
 
           try {
@@ -281,6 +282,13 @@ export const embarqueCargaMixin = {
             if (this.agregandoProducto) {
               console.log('[onSnapshot] Agregando producto en proceso, preservando productos locales');
               productosFinales = this.embarque.productos || [];
+              // Fusión PARCIAL: los productos remotos no se integraron, así
+              // que el estado local NO queda basado en esta revisión. Si la
+              // reclamáramos, la siguiente subida escribiría nuestra lista
+              // (sin los productos del otro editor) como si fuera la fusión
+              // completa y los borraría. Mantener la base anterior fuerza un
+              // conflicto→fusión completa en el siguiente intento.
+              this._revBase = revBaseAnterior;
             } else if (this.camposEnEdicion && this.camposEnEdicion.size > 0) {
               console.log('[onSnapshot] Hay campos en edición, mergear cuidadosamente');
               productosFinales = this.mergeProductosConCamposEnEdicion(productosDesdeServidor, productosFiltrados);
@@ -306,8 +314,11 @@ export const embarqueCargaMixin = {
                   // Preservar la versión local VIVA (lo que se está tecleando
                   // ahora mismo), no la copia tomada al crear el producto: la
                   // copia vieja pisaba lo recién escrito al aplicar snapshots.
+                  // Las filas creadas por el usuario se preservan aunque estén
+                  // vacías (las está por llenar); el descarte de placeholders
+                  // aplica solo a los renglones auto-creados (loop de abajo).
                   const productoVivo = productosLocalesActuales.find(p => p.id === id) || producto;
-                  if (!existeEnServidor && !esPlaceholderRedundante(productoVivo) && !eliminadosRemotos[id]) {
+                  if (!existeEnServidor && !eliminadosRemotos[id]) {
                     productosNuevosAPreservar.push(productoVivo);
                     this.productosNuevosPendientes.set(id, { ...productoVivo });
                     console.log('[onSnapshot] Preservando producto nuevo:', id);

--- a/src/views/Embarques/mixins/embarqueCargaMixin.js
+++ b/src/views/Embarques/mixins/embarqueCargaMixin.js
@@ -2,7 +2,7 @@ import { getFirestore, doc, onSnapshot, addDoc, collection } from 'firebase/fire
 import EmbarquesOfflineService from '@/services/EmbarquesOfflineService';
 import { normalizarFechaISO, obtenerFechaActualISO } from '@/utils/dateUtils';
 import { crearNuevoProducto } from '@/constants.js/embarque';
-import { embarqueTieneContenidoOperativoDoc, embarqueTieneContenidoOperativoEstado, productoTieneContenido, serializarEstable } from '@/utils/embarqueContenido';
+import { embarqueTieneContenidoOperativoDoc, embarqueTieneContenidoOperativoEstado, productoTieneContenido, serializarEstable, fusionarProductoTresVias } from '@/utils/embarqueContenido';
 
 export const esUUIDValido = (id) => {
   const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -265,28 +265,40 @@ export const embarqueCargaMixin = {
               );
             }
 
-            // Fusión de 3 vías a nivel producto: si la versión local difiere
-            // de la ÚLTIMA VERSIÓN SINCRONIZADA (base), el usuario la editó y
-            // su versión gana sobre la del servidor aunque el campo ya no
-            // tenga el foco. Sin esto, una fusión por conflicto revertía las
-            // ediciones locales aún no subidas ("el segundo cambio se
-            // perdía" cuando dos personas editaban a la vez).
+            // Fusión de 3 vías por producto contra la ÚLTIMA VERSIÓN
+            // SINCRONIZADA (base). Sin esto, una fusión por conflicto
+            // revertía las ediciones locales aún no subidas:
+            // - Solo lo local cambió → gana lo local completo.
+            // - Solo lo remoto cambió → gana lo remoto completo.
+            // - AMBOS cambiaron el mismo producto → fusión campo por campo
+            //   (usuario 1 borra kilos mientras usuario 2 agrega taras y
+            //   bolsas: sobreviven ambas intenciones).
             const baseSincronizada = this._productosBase instanceof Map ? this._productosBase : new Map();
             const productosLocalesParaMerge = this.embarque.productos || [];
             productosFiltrados = productosFiltrados.map((pServidor) => {
               const pLocal = productosLocalesParaMerge.find(p => p.id === pServidor.id);
               if (!pLocal) return pServidor;
-              const baseStr = baseSincronizada.get(pServidor.id);
-              if (baseStr && serializarEstable(pLocal) !== baseStr) {
+              const entradaBase = baseSincronizada.get(pServidor.id);
+              if (!entradaBase) return pServidor;
+              const localCambio = serializarEstable(pLocal) !== entradaBase.str;
+              if (!localCambio) return pServidor;
+              const remotoCambio = serializarEstable(pServidor) !== entradaBase.str;
+              if (!remotoCambio) {
                 console.log('[onSnapshot] Conservando edición local sin subir del producto:', pServidor.id);
                 return pLocal;
               }
-              return pServidor;
+              console.log('[onSnapshot] Producto editado por ambos: fusión campo por campo:', pServidor.id);
+              return fusionarProductoTresVias(entradaBase.obj, pLocal, pServidor);
             });
 
-            // La nueva base es lo que el SERVIDOR tiene en esta revisión.
+            // La nueva base es lo que el SERVIDOR tiene en esta revisión
+            // (clonada: los objetos del snapshot pasan al estado local y
+            // mutarían la base por referencia).
             this._productosBase = new Map(
-              productosDesdeServidor.map(p => [p.id, serializarEstable(p)])
+              productosDesdeServidor.map(p => [
+                p.id,
+                { obj: JSON.parse(JSON.stringify(p)), str: serializarEstable(p) }
+              ])
             );
 
             let productosFinales;

--- a/src/views/Embarques/mixins/embarqueCargaMixin.js
+++ b/src/views/Embarques/mixins/embarqueCargaMixin.js
@@ -2,7 +2,7 @@ import { getFirestore, doc, onSnapshot, addDoc, collection } from 'firebase/fire
 import EmbarquesOfflineService from '@/services/EmbarquesOfflineService';
 import { normalizarFechaISO, obtenerFechaActualISO } from '@/utils/dateUtils';
 import { crearNuevoProducto } from '@/constants.js/embarque';
-import { embarqueTieneContenidoOperativoDoc, embarqueTieneContenidoOperativoEstado, productoTieneContenido } from '@/utils/embarqueContenido';
+import { embarqueTieneContenidoOperativoDoc, embarqueTieneContenidoOperativoEstado, productoTieneContenido, serializarEstable } from '@/utils/embarqueContenido';
 
 export const esUUIDValido = (id) => {
   const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -153,18 +153,11 @@ export const embarqueCargaMixin = {
               }
             }
 
-            console.log('[DEBUG-FECHA] Cargando embarque ID:', id);
-            console.log('[DEBUG-FECHA] Fecha cruda de Firebase:', data.fecha);
-            console.log('[DEBUG-FECHA] Tipo de fecha:', typeof data.fecha, data.fecha?.constructor?.name);
-
             this.embarqueBloqueado = data.embarqueBloqueado || false;
 
             if (data.clientesPersonalizados && Array.isArray(data.clientesPersonalizados)) {
               this.clientesPersonalizados = data.clientesPersonalizados;
-              console.log('[cargarEmbarque] Clientes personalizados cargados desde Firebase:', this.clientesPersonalizados);
               localStorage.setItem('clientesPersonalizados', JSON.stringify(this.clientesPersonalizados));
-            } else {
-              console.log('[cargarEmbarque] No se encontraron clientes personalizados en Firebase, usando localStorage como respaldo');
             }
 
             if (data.clientesJuntarMedidas) {
@@ -217,20 +210,16 @@ export const embarqueCargaMixin = {
             let fecha;
             if (data.fecha && typeof data.fecha.toDate === 'function') {
               fecha = data.fecha.toDate();
-              console.log('[DEBUG-FECHA] Fecha convertida de Timestamp:', fecha);
             } else if (data.fecha instanceof Date) {
               fecha = data.fecha;
-              console.log('[DEBUG-FECHA] Fecha es Date object:', fecha);
             } else if (typeof data.fecha === 'string') {
               fecha = data.fecha;
-              console.log('[DEBUG-FECHA] Fecha es string:', fecha);
             } else {
               console.warn('Formato de fecha no reconocido, usando la fecha actual');
               fecha = new Date();
             }
 
             const fechaNormalizada = normalizarFechaISO(fecha);
-            console.log('[DEBUG-FECHA] Fecha normalizada final:', fechaNormalizada);
 
             const clientesPredefinidosMap = new Map(this.clientesPredefinidos.map(c => [c.id.toString(), c]));
 
@@ -271,16 +260,38 @@ export const embarqueCargaMixin = {
 
             let productosFiltrados = productosDesdeServidor.filter(p => !eliminadosRemotos[p.id]);
             if (this.productosEliminadosLocalmente && this.productosEliminadosLocalmente.size > 0) {
-              console.log('[onSnapshot] Filtrando productos eliminados localmente:', this.productosEliminadosLocalmente);
               productosFiltrados = productosFiltrados.filter(p =>
                 !this.productosEliminadosLocalmente.has(p.id)
               );
             }
 
+            // Fusión de 3 vías a nivel producto: si la versión local difiere
+            // de la ÚLTIMA VERSIÓN SINCRONIZADA (base), el usuario la editó y
+            // su versión gana sobre la del servidor aunque el campo ya no
+            // tenga el foco. Sin esto, una fusión por conflicto revertía las
+            // ediciones locales aún no subidas ("el segundo cambio se
+            // perdía" cuando dos personas editaban a la vez).
+            const baseSincronizada = this._productosBase instanceof Map ? this._productosBase : new Map();
+            const productosLocalesParaMerge = this.embarque.productos || [];
+            productosFiltrados = productosFiltrados.map((pServidor) => {
+              const pLocal = productosLocalesParaMerge.find(p => p.id === pServidor.id);
+              if (!pLocal) return pServidor;
+              const baseStr = baseSincronizada.get(pServidor.id);
+              if (baseStr && serializarEstable(pLocal) !== baseStr) {
+                console.log('[onSnapshot] Conservando edición local sin subir del producto:', pServidor.id);
+                return pLocal;
+              }
+              return pServidor;
+            });
+
+            // La nueva base es lo que el SERVIDOR tiene en esta revisión.
+            this._productosBase = new Map(
+              productosDesdeServidor.map(p => [p.id, serializarEstable(p)])
+            );
+
             let productosFinales;
 
             if (this.agregandoProducto) {
-              console.log('[onSnapshot] Agregando producto en proceso, preservando productos locales');
               productosFinales = this.embarque.productos || [];
               // Fusión PARCIAL: los productos remotos no se integraron, así
               // que el estado local NO queda basado en esta revisión. Si la
@@ -290,7 +301,6 @@ export const embarqueCargaMixin = {
               // conflicto→fusión completa en el siguiente intento.
               this._revBase = revBaseAnterior;
             } else if (this.camposEnEdicion && this.camposEnEdicion.size > 0) {
-              console.log('[onSnapshot] Hay campos en edición, mergear cuidadosamente');
               productosFinales = this.mergeProductosConCamposEnEdicion(productosDesdeServidor, productosFiltrados);
             } else {
               // Placeholder redundante: renglón vacío de un cliente que ya
@@ -308,7 +318,6 @@ export const embarqueCargaMixin = {
 
               const productosNuevosAPreservar = [];
               if (this.productosNuevosPendientes && this.productosNuevosPendientes.size > 0) {
-                console.log('[onSnapshot] Preservando productos nuevos pendientes:', this.productosNuevosPendientes.size);
                 this.productosNuevosPendientes.forEach((producto, id) => {
                   const existeEnServidor = productosDesdeServidor.some(p => p.id === id);
                   // Preservar la versión local VIVA (lo que se está tecleando
@@ -321,10 +330,8 @@ export const embarqueCargaMixin = {
                   if (!existeEnServidor && !eliminadosRemotos[id]) {
                     productosNuevosAPreservar.push(productoVivo);
                     this.productosNuevosPendientes.set(id, { ...productoVivo });
-                    console.log('[onSnapshot] Preservando producto nuevo:', id);
                   } else {
                     this.productosNuevosPendientes.delete(id);
-                    console.log('[onSnapshot] Producto sincronizado, borrado o placeholder redundante, removiendo de pendientes:', id);
                   }
                 });
               }
@@ -334,7 +341,6 @@ export const embarqueCargaMixin = {
                     !productosNuevosAPreservar.some(p => p.id === productoLocal.id) &&
                     !esPlaceholderRedundante(productoLocal) &&
                     !eliminadosRemotos[productoLocal.id]) {
-                  console.log('[onSnapshot] Preservando producto local no sincronizado:', productoLocal.id);
                   productosNuevosAPreservar.push(productoLocal);
                   if (!this.productosNuevosPendientes.has(productoLocal.id)) {
                     this.productosNuevosPendientes.set(productoLocal.id, { ...productoLocal });
@@ -352,9 +358,6 @@ export const embarqueCargaMixin = {
               productos: productosFinales,
               kilosCrudos: data.kilosCrudos || {}
             };
-
-            console.log('[DEBUG-FECHA] Embarque asignado con fecha:', this.embarque.fecha);
-            console.log('[DEBUG-FECHA] Total productos cargados:', productosFinales.length);
 
             this.costosPorMedida = { ...(data.costosPorMedida || {}) };
             this.aplicarCostoExtra = { ...(data.aplicarCostoExtra || {}) };

--- a/src/views/Embarques/mixins/embarqueCargaMixin.js
+++ b/src/views/Embarques/mixins/embarqueCargaMixin.js
@@ -296,13 +296,20 @@ export const embarqueCargaMixin = {
                 !productoTieneContenido(producto) &&
                 clientesConProductosEnServidor.has(String(producto.clienteId));
 
+              const productosLocalesActuales = this.embarque.productos || [];
+
               const productosNuevosAPreservar = [];
               if (this.productosNuevosPendientes && this.productosNuevosPendientes.size > 0) {
                 console.log('[onSnapshot] Preservando productos nuevos pendientes:', this.productosNuevosPendientes.size);
                 this.productosNuevosPendientes.forEach((producto, id) => {
                   const existeEnServidor = productosDesdeServidor.some(p => p.id === id);
-                  if (!existeEnServidor && !esPlaceholderRedundante(producto) && !eliminadosRemotos[id]) {
-                    productosNuevosAPreservar.push(producto);
+                  // Preservar la versión local VIVA (lo que se está tecleando
+                  // ahora mismo), no la copia tomada al crear el producto: la
+                  // copia vieja pisaba lo recién escrito al aplicar snapshots.
+                  const productoVivo = productosLocalesActuales.find(p => p.id === id) || producto;
+                  if (!existeEnServidor && !esPlaceholderRedundante(productoVivo) && !eliminadosRemotos[id]) {
+                    productosNuevosAPreservar.push(productoVivo);
+                    this.productosNuevosPendientes.set(id, { ...productoVivo });
                     console.log('[onSnapshot] Preservando producto nuevo:', id);
                   } else {
                     this.productosNuevosPendientes.delete(id);
@@ -310,8 +317,6 @@ export const embarqueCargaMixin = {
                   }
                 });
               }
-
-              const productosLocalesActuales = this.embarque.productos || [];
               productosLocalesActuales.forEach(productoLocal => {
                 if (esUUIDValido(productoLocal.id) &&
                     !productosDesdeServidor.some(p => p.id === productoLocal.id) &&

--- a/src/views/Embarques/mixins/embarqueCargaMixin.js
+++ b/src/views/Embarques/mixins/embarqueCargaMixin.js
@@ -54,16 +54,72 @@ export const embarqueCargaMixin = {
       const db = getFirestore();
       const embarqueRef = doc(db, "embarques", id);
 
-      this.unsubscribe = onSnapshot(embarqueRef, async (doc) => {
-        if (this.hasPendingChanges) {
-          console.log('[onSnapshot] Ignorando actualización remota porque hay cambios locales pendientes.');
+      this.unsubscribe = onSnapshot(embarqueRef, async (docSnapshot) => {
+        // Eco optimista de una escritura local pendiente de confirmar: ignorar.
+        if (docSnapshot.metadata && docSnapshot.metadata.hasPendingWrites) {
           return;
         }
 
-        if (doc.exists()) {
-          const data = doc.data();
+        if (docSnapshot.exists()) {
+          const data = docSnapshot.data();
+
+          if (this.hasPendingChanges) {
+            // Hay cambios locales sin subir: aplicar lo remoto ahora pisaría
+            // lo que se está capturando. Se difiere; la subida transaccional
+            // (subirCambiosEnVivo) detecta la revisión nueva y fusiona.
+            this._snapshotRemotoDiferido = data;
+            return;
+          }
+
+          this._snapshotRemotoDiferido = null;
+          await this.aplicarDocRemoto(id, data);
+        } else {
+          this.cargarEmbarqueOffline(id).then((cargadoOffline) => {
+            if (cargadoOffline) {
+              this._inicializandoEmbarque = false;
+              this._aplicandoRemoto = false;
+              return;
+            }
+            alert('No se encontró el embarque en nube ni en cache local para ese ID. Se conservará el estado actual; verifica conexión y vuelve a intentar.');
+            this._inicializandoEmbarque = false;
+            this._aplicandoRemoto = false;
+          });
+        }
+      }, (error) => {
+        console.error("Error al escuchar cambios del embarque:", error);
+
+        if (error.code === 'unavailable' || error.message.includes('network') || error.message.includes('NETWORK')) {
+          console.warn('[onSnapshot] Error de red detectado, reintentando conexión en 5 segundos...');
+          setTimeout(() => {
+            if (this.embarqueId && !this.unsubscribe) {
+              console.log('[onSnapshot] Reintentando conexión...');
+              this.cargarEmbarque(this.embarqueId);
+            }
+          }, 5000);
+        } else if (error.code === 'permission-denied') {
+          console.error('[onSnapshot] Error de permisos:', error);
+          alert('Error de permisos. Por favor, verifique su acceso.');
+        } else {
+          console.error('[onSnapshot] Error desconocido:', error);
+        }
+
+        this._inicializandoEmbarque = false;
+        this._aplicandoRemoto = false;
+      });
+    },
+
+    /**
+     * Aplica un documento remoto del embarque al estado local, fusionando con
+     * protecciones para lo que se está editando (campos con foco, productos
+     * nuevos sin sincronizar, productos eliminados localmente). También lo usa
+     * la subida transaccional cuando detecta un conflicto de revisión.
+     */
+    async aplicarDocRemoto(id, data) {
           data.clientes = Array.isArray(data.clientes) ? data.clientes : [];
           this._aplicandoRemoto = true;
+          // Revisión remota sobre la que queda basado el estado local
+          // (subirCambiosEnVivo la usa para detectar conflictos).
+          this._revBase = Number(data.rev) || 0;
 
           try {
             if (!this.tieneContenidoOperativo(data)) {
@@ -277,39 +333,6 @@ export const embarqueCargaMixin = {
           }
 
           this.guardarSnapshotOffline({ pendingSync: false, docData: data, syncState: 'synced' });
-        } else {
-          this.cargarEmbarqueOffline(id).then((cargadoOffline) => {
-            if (cargadoOffline) {
-              this._inicializandoEmbarque = false;
-              this._aplicandoRemoto = false;
-              return;
-            }
-            alert('No se encontró el embarque en nube ni en cache local para ese ID. Se conservará el estado actual; verifica conexión y vuelve a intentar.');
-            this._inicializandoEmbarque = false;
-            this._aplicandoRemoto = false;
-          });
-        }
-      }, (error) => {
-        console.error("Error al escuchar cambios del embarque:", error);
-
-        if (error.code === 'unavailable' || error.message.includes('network') || error.message.includes('NETWORK')) {
-          console.warn('[onSnapshot] Error de red detectado, reintentando conexión en 5 segundos...');
-          setTimeout(() => {
-            if (this.embarqueId && !this.unsubscribe) {
-              console.log('[onSnapshot] Reintentando conexión...');
-              this.cargarEmbarque(this.embarqueId);
-            }
-          }, 5000);
-        } else if (error.code === 'permission-denied') {
-          console.error('[onSnapshot] Error de permisos:', error);
-          alert('Error de permisos. Por favor, verifique su acceso.');
-        } else {
-          console.error('[onSnapshot] Error desconocido:', error);
-        }
-
-        this._inicializandoEmbarque = false;
-        this._aplicandoRemoto = false;
-      });
     },
 
     limpiarConexionesFirestore() {

--- a/src/views/Embarques/mixins/embarquePresenciaMixin.js
+++ b/src/views/Embarques/mixins/embarquePresenciaMixin.js
@@ -1,10 +1,12 @@
-import { ref, onValue, onDisconnect, set } from 'firebase/database';
+import { ref, onValue, onDisconnect, set, remove } from 'firebase/database';
 import { rtdb } from '@/firebase';
 
 export const embarquePresenciaMixin = {
   data() {
     return {
       usuariosActivos: [],
+      // Usuarios editando ESTE embarque en este momento (sin incluirme)
+      editoresEmbarque: [],
     };
   },
 
@@ -12,9 +14,76 @@ export const embarquePresenciaMixin = {
     if (this.unsubscribeUsuarios) {
       this.unsubscribeUsuarios();
     }
+    this.detenerPresenciaEmbarque();
   },
 
   methods: {
+    /**
+     * Presencia por embarque: registra a este usuario como editor del
+     * embarque en Realtime Database y escucha quién más lo está editando,
+     * para mostrarlo en la interfaz. Se limpia al desconectar (onDisconnect),
+     * al salir de la vista o al cambiar de embarque.
+     */
+    iniciarPresenciaEmbarque(embarqueId) {
+      this.detenerPresenciaEmbarque();
+
+      const userId = this.authStore?.userId;
+      const username = this.authStore?.user?.username || 'Usuario';
+      if (!embarqueId || !userId) return;
+
+      try {
+        const propioRef = ref(rtdb, `presenciaEmbarques/${embarqueId}/${userId}`);
+        this._presenciaEmbarquePropioRef = propioRef;
+
+        const registrar = () => set(propioRef, {
+          username,
+          conectadoEn: Date.now()
+        }).catch(() => {});
+
+        registrar();
+        onDisconnect(propioRef).remove().catch(() => {});
+        // Refresco periódico: permite descartar registros huérfanos si algún
+        // onDisconnect no llegó a ejecutarse (cierres abruptos).
+        this._presenciaEmbarqueHeartbeat = setInterval(registrar, 60000);
+
+        const salaRef = ref(rtdb, `presenciaEmbarques/${embarqueId}`);
+        this._presenciaEmbarqueUnsub = onValue(salaRef, (snapshot) => {
+          const valores = snapshot.val() || {};
+          const ahora = Date.now();
+          this.editoresEmbarque = Object.entries(valores)
+            .filter(([uid, info]) =>
+              uid !== userId &&
+              info &&
+              (ahora - (Number(info.conectadoEn) || 0)) < 5 * 60 * 1000
+            )
+            .map(([, info]) => info.username || 'Alguien');
+        }, (error) => {
+          console.warn('[presenciaEmbarque] No se pudo escuchar la presencia:', error);
+        });
+      } catch (error) {
+        console.warn('[presenciaEmbarque] Presencia no disponible:', error);
+      }
+    },
+
+    detenerPresenciaEmbarque() {
+      if (this._presenciaEmbarqueHeartbeat) {
+        clearInterval(this._presenciaEmbarqueHeartbeat);
+        this._presenciaEmbarqueHeartbeat = null;
+      }
+      if (this._presenciaEmbarqueUnsub) {
+        try { this._presenciaEmbarqueUnsub(); } catch (_) { /* noop */ }
+        this._presenciaEmbarqueUnsub = null;
+      }
+      if (this._presenciaEmbarquePropioRef) {
+        try {
+          onDisconnect(this._presenciaEmbarquePropioRef).cancel().catch(() => {});
+          remove(this._presenciaEmbarquePropioRef).catch(() => {});
+        } catch (_) { /* noop */ }
+        this._presenciaEmbarquePropioRef = null;
+      }
+      this.editoresEmbarque = [];
+    },
+
     async iniciarPresenciaUsuario() {
       try {
         if (!this.authStore.isLoggedIn || !this.authStore.user) return;

--- a/src/views/Embarques/mixins/embarqueSyncMixin.js
+++ b/src/views/Embarques/mixins/embarqueSyncMixin.js
@@ -354,6 +354,14 @@ export const embarqueSyncMixin = {
         if (record.id === this.embarqueId) {
           this.guardadoAutomaticoActivo = true;
           this.modoEdicion = true;
+          // El embarque abierto acaba de subirse: ya no hay cambios locales
+          // pendientes y nuestra base es la revisión recién escrita. Sin este
+          // reset, hasPendingChanges quedaba en true para siempre y TODOS los
+          // snapshots remotos se diferían: la otra sesión dejaba de reflejarse
+          // hasta la siguiente edición local.
+          this.hasPendingChanges = false;
+          this._revBase = Number(dataParaFirestore.rev) || Number(this._revBase) || 0;
+          this._snapshotRemotoDiferido = null;
         }
       } catch (error) {
         console.error('[sincronizarRegistroOffline] Error al sincronizar embarque offline:', error);

--- a/src/views/Embarques/mixins/embarqueSyncMixin.js
+++ b/src/views/Embarques/mixins/embarqueSyncMixin.js
@@ -1,4 +1,4 @@
-import { getFirestore, doc, updateDoc, setDoc, getDoc, serverTimestamp, deleteDoc } from 'firebase/firestore';
+import { getFirestore, doc, updateDoc, setDoc, getDoc, serverTimestamp, deleteDoc, runTransaction } from 'firebase/firestore';
 import { v4 as uuidv4 } from 'uuid';
 import EmbarquesOfflineService from '@/services/EmbarquesOfflineService';
 import BackupService from '../BackupService.js';
@@ -104,6 +104,10 @@ export function normalizarDocDataParaFirestore(docData, record = {}, contexto = 
     }
   });
 
+  // Señal de cambio para los editores en vivo: cada sincronización cuenta
+  // como una revisión nueva sobre lo remoto.
+  data.rev = (Number(pickPreferRemoto('rev')) || 0) + 1;
+
   data.clientes = data.clientes.map(cliente => ({
     ...cliente,
     productos: Array.isArray(cliente.productos) ? cliente.productos.map(producto => ({
@@ -118,6 +122,12 @@ export function normalizarDocDataParaFirestore(docData, record = {}, contexto = 
 }
 
 export const embarqueSyncMixin = {
+  beforeDestroy() {
+    if (this._timerSubidaEnVivo) {
+      clearTimeout(this._timerSubidaEnVivo);
+      this._timerSubidaEnVivo = null;
+    }
+  },
   methods: {
     async guardarEmbarqueInicial(clienteId) {
       const modalAbierto = this.mostrarModalPrecio ||
@@ -204,8 +214,12 @@ export const embarqueSyncMixin = {
         const embarqueData = this.prepararDatosEmbarque();
         const snap = await getDoc(embarqueRef);
 
+        // Señal de cambio para editores en vivo (control de revisiones)
+        const revNueva = (snap.exists() ? (Number(snap.data().rev) || 0) : (Number(this._revBase) || 0)) + 1;
+
         const payload = {
           ...embarqueData,
+          rev: revNueva,
           ultimaEdicion: {
             userId: this.authStore.userId,
             username: this.authStore.user?.username || 'Usuario desconocido',
@@ -218,6 +232,8 @@ export const embarqueSyncMixin = {
         } else {
           await setDoc(embarqueRef, payload);
         }
+
+        this._revBase = revNueva;
 
         await EmbarquesOfflineService.markSynced(this.embarqueId);
         this.hasPendingChanges = false;
@@ -361,7 +377,119 @@ export const embarqueSyncMixin = {
 
       console.log('Cambios guardados localmente:', new Date().toLocaleString());
       this.$emit('guardado-automatico');
+
+      // Edición colaborativa: subir automáticamente a la nube para que otros
+      // editores vean los cambios en vivo (sin esperar al botón de subir).
+      if (navigator.onLine) {
+        if (immediate) {
+          this.subirCambiosEnVivo();
+        } else {
+          this.programarSubidaEnVivo();
+        }
+      }
       return Promise.resolve();
+    },
+
+    programarSubidaEnVivo() {
+      if (this._timerSubidaEnVivo) {
+        clearTimeout(this._timerSubidaEnVivo);
+      }
+      this._timerSubidaEnVivo = setTimeout(() => {
+        this._timerSubidaEnVivo = null;
+        this.subirCambiosEnVivo();
+      }, 1500);
+    },
+
+    /**
+     * Sube los cambios locales a Firestore con control de revisiones para
+     * edición colaborativa: la escritura solo procede si nadie más guardó
+     * desde la última revisión que aplicamos (campo `rev`). Si otra persona
+     * guardó primero, NO se pisa su trabajo: se fusiona el documento remoto
+     * al estado local (aplicarDocRemoto protege lo que se está editando) y
+     * se reintenta la subida con el estado fusionado.
+     */
+    async subirCambiosEnVivo() {
+      if (!this.embarqueId || !this.hasPendingChanges || !navigator.onLine) {
+        return;
+      }
+      if (this._subiendoEnVivo) {
+        this._resubirAlTerminar = true;
+        return;
+      }
+      this._subiendoEnVivo = true;
+
+      try {
+        const db = getFirestore();
+        const embarqueRef = doc(db, 'embarques', this.embarqueId);
+        const payload = {
+          ...this.prepararDatosEmbarque(),
+          ultimaEdicion: {
+            userId: this.authStore.userId,
+            username: this.authStore.user?.username || 'Usuario desconocido',
+            timestamp: serverTimestamp()
+          }
+        };
+
+        let dataConflicto = null;
+        let revEscrita = null;
+
+        await runTransaction(db, async (transaction) => {
+          dataConflicto = null;
+          const snapshot = await transaction.get(embarqueRef);
+
+          if (!snapshot.exists()) {
+            revEscrita = (Number(this._revBase) || 0) + 1;
+            transaction.set(embarqueRef, { ...payload, rev: revEscrita });
+            return;
+          }
+
+          const revRemota = Number(snapshot.data().rev) || 0;
+          if (revRemota !== (Number(this._revBase) || 0)) {
+            // Alguien más guardó desde nuestra base: no escribir nada.
+            dataConflicto = snapshot.data();
+            return;
+          }
+
+          revEscrita = revRemota + 1;
+          // update (no set): conserva campos que otras vistas escriben en el
+          // mismo documento (fletePagos, totalGanancias, etc.).
+          transaction.update(embarqueRef, { ...payload, rev: revEscrita });
+        });
+
+        if (dataConflicto) {
+          this._reintentosSubidaEnVivo = (this._reintentosSubidaEnVivo || 0) + 1;
+          if (this._reintentosSubidaEnVivo > 4) {
+            console.warn('[subirCambiosEnVivo] Demasiados conflictos seguidos; se reintentará con el próximo cambio.');
+            this._reintentosSubidaEnVivo = 0;
+            return;
+          }
+          console.log('[subirCambiosEnVivo] Conflicto de revisión: fusionando cambios remotos antes de subir.');
+          // hasPendingChanges se queda en true durante la fusión: cualquier
+          // snapshot que llegue en medio se difiere en vez de aplicarse encima.
+          this._snapshotRemotoDiferido = null;
+          await this.aplicarDocRemoto(this.embarqueId, dataConflicto);
+          await this.guardarSnapshotOffline({ pendingSync: true });
+          this.programarSubidaEnVivo();
+          return;
+        }
+
+        this._revBase = revEscrita;
+        this._reintentosSubidaEnVivo = 0;
+        this.hasPendingChanges = false;
+        this._snapshotRemotoDiferido = null;
+        await this.guardarSnapshotOffline({ pendingSync: false, syncState: 'synced' });
+        console.log('[subirCambiosEnVivo] Cambios sincronizados con la nube (rev', revEscrita + ').');
+      } catch (error) {
+        console.error('[subirCambiosEnVivo] Error al subir cambios:', error);
+        // El espejo offline conserva pendingSync: se reintenta con el próximo
+        // cambio, al reconectar, o con el botón de subir manual.
+      } finally {
+        this._subiendoEnVivo = false;
+        if (this._resubirAlTerminar) {
+          this._resubirAlTerminar = false;
+          this.programarSubidaEnVivo();
+        }
+      }
     },
 
     async guardarEmbarque() {
@@ -383,7 +511,9 @@ export const embarqueSyncMixin = {
 
       try {
         await this.guardarCambiosEnTiempoReal(true);
-        this.mostrarMensaje('Embarque guardado localmente. Recuerde subir los cambios para respaldar en la nube.');
+        this.mostrarMensaje(navigator.onLine
+          ? 'Embarque guardado. Los cambios se sincronizan automáticamente con la nube.'
+          : 'Embarque guardado localmente. Se subirá a la nube al recuperar la conexión.');
       } catch (error) {
         console.error("Error al guardar localmente:", error);
         alert('Error al guardar localmente.');

--- a/src/views/Embarques/mixins/embarqueSyncMixin.js
+++ b/src/views/Embarques/mixins/embarqueSyncMixin.js
@@ -108,6 +108,13 @@ export function normalizarDocDataParaFirestore(docData, record = {}, contexto = 
   // como una revisión nueva sobre lo remoto.
   data.rev = (Number(pickPreferRemoto('rev')) || 0) + 1;
 
+  // Lápidas de borrado de productos: unión de lo local y lo remoto para que
+  // una sincronización no reviva productos borrados por otro editor.
+  data.productosEliminados = {
+    ...((contexto.dataRemota && contexto.dataRemota.productosEliminados) || {}),
+    ...(dataCruda.productosEliminados || record.productosEliminados || {})
+  };
+
   data.clientes = data.clientes.map(cliente => ({
     ...cliente,
     productos: Array.isArray(cliente.productos) ? cliente.productos.map(producto => ({
@@ -521,11 +528,31 @@ export const embarqueSyncMixin = {
     },
 
     prepararDatosEmbarque() {
+      // Lápidas de borrado: registro de productos eliminados para que los
+      // demás editores en vivo los quiten en lugar de "preservarlos" como si
+      // fueran productos nuevos del otro lado. Se depuran a los 7 días.
+      const productosEliminados = { ...(this._productosEliminadosDoc || {}) };
+      const ahora = Date.now();
+      if (this.productosEliminadosLocalmente) {
+        this.productosEliminadosLocalmente.forEach((idProducto) => {
+          if (!productosEliminados[idProducto]) {
+            productosEliminados[idProducto] = ahora;
+          }
+        });
+      }
+      Object.keys(productosEliminados).forEach((idProducto) => {
+        if (ahora - Number(productosEliminados[idProducto] || 0) > 7 * 24 * 60 * 60 * 1000) {
+          delete productosEliminados[idProducto];
+        }
+      });
+      this._productosEliminadosDoc = productosEliminados;
+
       const embarqueData = {
         fecha: this.embarque.fecha,
         cargaCon: this.embarque.cargaCon,
         camionNumero: this.embarque.camionNumero || 1,
         kilosCrudos: this.embarque.kilosCrudos || {},
+        productosEliminados,
         clientes: [],
         borrador: !embarqueTieneContenidoOperativoEstado({
           cargaCon: this.embarque?.cargaCon,

--- a/src/views/Embarques/mixins/embarqueSyncMixin.js
+++ b/src/views/Embarques/mixins/embarqueSyncMixin.js
@@ -363,7 +363,10 @@ export const embarqueSyncMixin = {
           this._revBase = Number(dataParaFirestore.rev) || Number(this._revBase) || 0;
           this._snapshotRemotoDiferido = null;
           this._productosBase = new Map(
-            (this.embarque.productos || []).map(p => [p.id, serializarEstable(p)])
+            (this.embarque.productos || []).map(p => [
+              p.id,
+              { obj: JSON.parse(JSON.stringify(p)), str: serializarEstable(p) }
+            ])
           );
         }
       } catch (error) {
@@ -505,7 +508,10 @@ export const embarqueSyncMixin = {
         // El estado local acaba de subirse tal cual: es la nueva base
         // sincronizada para la fusión de 3 vías de productos.
         this._productosBase = new Map(
-          (this.embarque.productos || []).map(p => [p.id, serializarEstable(p)])
+          (this.embarque.productos || []).map(p => [
+            p.id,
+            { obj: JSON.parse(JSON.stringify(p)), str: serializarEstable(p) }
+          ])
         );
         await this.guardarSnapshotOffline({ pendingSync: false, syncState: 'synced' });
         console.log('[subirCambiosEnVivo] Cambios sincronizados con la nube (rev', revEscrita + ').');

--- a/src/views/Embarques/mixins/embarqueSyncMixin.js
+++ b/src/views/Embarques/mixins/embarqueSyncMixin.js
@@ -4,7 +4,7 @@ import EmbarquesOfflineService from '@/services/EmbarquesOfflineService';
 import BackupService from '../BackupService.js';
 import { normalizarFechaISO, normalizarFechaValor, obtenerFechaActualISO } from '@/utils/dateUtils';
 import { crearNuevoProducto } from '@/constants.js/embarque';
-import { embarqueTieneContenidoOperativoEstado } from '@/utils/embarqueContenido';
+import { embarqueTieneContenidoOperativoEstado, serializarEstable } from '@/utils/embarqueContenido';
 
 /**
  * Normaliza los datos de un embarque para escribirlos en Firestore.
@@ -362,6 +362,9 @@ export const embarqueSyncMixin = {
           this.hasPendingChanges = false;
           this._revBase = Number(dataParaFirestore.rev) || Number(this._revBase) || 0;
           this._snapshotRemotoDiferido = null;
+          this._productosBase = new Map(
+            (this.embarque.productos || []).map(p => [p.id, serializarEstable(p)])
+          );
         }
       } catch (error) {
         console.error('[sincronizarRegistroOffline] Error al sincronizar embarque offline:', error);
@@ -390,7 +393,6 @@ export const embarqueSyncMixin = {
       this.hasPendingChanges = true;
       await this.guardarSnapshotOffline({ pendingSync: true });
 
-      console.log('Cambios guardados localmente:', new Date().toLocaleString());
       this.$emit('guardado-automatico');
 
       // Edición colaborativa: subir automáticamente a la nube para que otros
@@ -492,6 +494,11 @@ export const embarqueSyncMixin = {
         this._reintentosSubidaEnVivo = 0;
         this.hasPendingChanges = false;
         this._snapshotRemotoDiferido = null;
+        // El estado local acaba de subirse tal cual: es la nueva base
+        // sincronizada para la fusión de 3 vías de productos.
+        this._productosBase = new Map(
+          (this.embarque.productos || []).map(p => [p.id, serializarEstable(p)])
+        );
         await this.guardarSnapshotOffline({ pendingSync: false, syncState: 'synced' });
         console.log('[subirCambiosEnVivo] Cambios sincronizados con la nube (rev', revEscrita + ').');
       } catch (error) {

--- a/src/views/Embarques/mixins/embarqueSyncMixin.js
+++ b/src/views/Embarques/mixins/embarqueSyncMixin.js
@@ -407,14 +407,17 @@ export const embarqueSyncMixin = {
       return Promise.resolve();
     },
 
-    programarSubidaEnVivo() {
+    programarSubidaEnVivo(retrasoMs) {
+      // Jitter: si dos sesiones agendan la subida con la misma cadencia fija,
+      // chocan sincronizadas en conflictos una y otra vez.
+      const retraso = retrasoMs || (1500 + Math.floor(Math.random() * 700));
       if (this._timerSubidaEnVivo) {
         clearTimeout(this._timerSubidaEnVivo);
       }
       this._timerSubidaEnVivo = setTimeout(() => {
         this._timerSubidaEnVivo = null;
         this.subirCambiosEnVivo();
-      }, 1500);
+      }, retraso);
     },
 
     /**
@@ -476,8 +479,13 @@ export const embarqueSyncMixin = {
         if (dataConflicto) {
           this._reintentosSubidaEnVivo = (this._reintentosSubidaEnVivo || 0) + 1;
           if (this._reintentosSubidaEnVivo > 4) {
-            console.warn('[subirCambiosEnVivo] Demasiados conflictos seguidos; se reintentará con el próximo cambio.');
+            // NUNCA abandonar cambios pendientes: si el otro editor está
+            // tecleando sin parar, esperar más largo y volver a intentar.
+            // (Antes se esperaba "al próximo cambio local", que podía no
+            // llegar nunca — un borrado quedaba sin subir para siempre.)
+            console.warn('[subirCambiosEnVivo] Muchos conflictos seguidos; reintentando con espera más larga.');
             this._reintentosSubidaEnVivo = 0;
+            this.programarSubidaEnVivo(6000 + Math.floor(Math.random() * 3000));
             return;
           }
           console.log('[subirCambiosEnVivo] Conflicto de revisión: fusionando cambios remotos antes de subir.');


### PR DESCRIPTION
## Resumen

Dos personas ya pueden editar el mismo embarque al mismo tiempo sin pisarse, con sincronización automática en vivo. Antes el editor era offline-first con subida manual del documento completo: el último en subir borraba el trabajo del otro, y mientras hubiera cambios locales pendientes se ignoraban todos los cambios remotos.

## Cómo funciona

- **Subida automática con control de revisiones**: cada cambio sube solo (debounce 1.5–2.2s con jitter) mediante una transacción que verifica el campo `rev`. Si alguien más guardó primero, no se pisa: se fusiona lo remoto y se reintenta con el estado combinado — reintentos con espera progresiva, nunca se abandonan cambios pendientes.
- **Fusión de 3 vías por producto y por campo**: cada editor recuerda la última versión sincronizada (base). Producto editado solo por ti → gana tu versión; solo por él → entra la suya; **por ambos → fusión campo por campo** (uno borra kilos mientras el otro agrega taras/bolsas: sobreviven ambas intenciones). Campos con el cursor encima quedan protegidos además por el tracking de campos en edición.
- **Lápidas de borrado** (`productosEliminados`): al borrar un producto la lápida se publica de inmediato con un update puntual (durable aunque el otro esté tecleando) y todas las rutas de fusión la respetan — los borrados no reviven. Depuración automática a 7 días.
- **Presencia por embarque**: banner "👥 También editando ahora: X" vía Realtime Database con limpieza `onDisconnect` y heartbeat.
- **Placeholders sin duplicarse**: los renglones vacíos auto-creados por cada editor se deduplican en la fusión; las filas creadas por el usuario se preservan siempre con su versión viva (lo tecleado no se borra).

## Correcciones de bugs encontrados en pruebas reales (2 usuarios)

- Bucle infinito de subidas sin cambios (eco re-aplicado + banderas de watcher liberadas antes de tiempo — `_aplicandoRemoto` ahora se libera en `$nextTick`, bug preexistente).
- Sesión que dejaba de reflejar al otro editor: el sync offline no reseteaba `hasPendingChanges` y todos los snapshots se diferían para siempre.
- Texto borrado al teclear rápido en productos recién agregados (se preservaba una copia vacía tomada al crear).
- Borrados que no se publicaban si el otro editor tecleaba sin parar (la subida se rendía tras 4 conflictos).
- `toggleBloqueo` ahora incrementa `rev` para que los demás vean el candado.
- Lápida local registrada solo cuando el borrado realmente procede.
- Consola limpia: fuera los logs por snapshot/tecleo; quedan los eventos con señal (conflicto, sincronizado, fusión campo a campo, edición local conservada).

## Compatibilidad

- El flujo offline no cambia: sin conexión se guarda al espejo local (IndexedDB) y sube al reconectar.
- Documentos sin `rev` (todos los existentes) arrancan en 0 y adoptan el protocolo con la primera escritura.
- La subida usa `transaction.update`: los campos escritos por otras vistas (`fletePagos`, `totalGanancias`, etc.) no se tocan.
- Los `400 (failed-precondition)` de Firestore en la consola del navegador son esperados: es el rechazo de escrituras basadas en revisión vieja (la protección actuando); el SDK reintenta y fusiona.

## Verificación

- Probado en vivo por dos usuarios reales en múltiples rondas (agregar/editar/borrar simultáneos, mismo producto, corte de red); cada bug encontrado fue corregido y re-probado.
- Máquina de estados de subida validada con Firestore simulado (10 escenarios); fusión campo a campo con 8 casos del escenario real; helpers de lápidas y placeholders con pruebas propias.
- `npm run build:web` pasa completo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CFmXhJcButeUhZG6sx7Kk2

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFmXhJcButeUhZG6sx7Kk2)_