### PR TITLE
Add shipment comparison feature to daily crude records

### DIFF
--- a/src/NavBar.vue
+++ b/src/NavBar.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="predator-nav-wrapper">
+  <div class="predator-nav-wrapper" v-if="!ocultarNavbar">
     <div class="safe-area-top"></div>
     
     <!-- Scanlines overlay -->
@@ -292,12 +292,19 @@
 </template>
 
 <script>
+import { useUIStore } from './stores/ui';
+
 export default {
   name: "Navbar",
   data() {
     return {
       mobileMenuOpen: false
     };
+  },
+  computed: {
+    ocultarNavbar() {
+      return !!useUIStore().activeModal;
+    }
   },
   methods: {
     toggleMobileMenu() {

--- a/src/views/Embarques/components/GenerarEsqueletoEmbarqueButton.vue
+++ b/src/views/Embarques/components/GenerarEsqueletoEmbarqueButton.vue
@@ -45,7 +45,8 @@ const MEDIDAS_CRUDOS_MAP = {
   'linea': 'Linea',
   'lag gde': 'Lag gde c/c',
   'acamaya': 'Acamaya',
-  'rechazo': 'Rechazo'
+  'rechazo': 'Rechazo',
+  'cam s/c': 'Cam s/c'
 };
 
 const MEDIDAS_CRUDOS_ORDEN = [

--- a/src/views/ExistenciasCrudos.vue
+++ b/src/views/ExistenciasCrudos.vue
@@ -231,6 +231,16 @@
       :registros="registros"
       @cerrar="cerrarModalEntradasProveedor"
     />
+
+    <!-- Modal rápido: solo la sección de salidas del día -->
+    <div v-if="modalSalida.abierto" class="modal-overlay" @click.self="cerrarModalSalida">
+      <RegistroCrudos
+        modo-modal
+        :registro-id-prop="modalSalida.registroId"
+        @guardado="onSalidaGuardada"
+        @cerrar="cerrarModalSalida"
+      />
+    </div>
   </div>
 </template>
 
@@ -241,13 +251,15 @@ import moment from 'moment';
 import PapeleraService from '@/services/PapeleraService';
 import GestionProveedoresCrudos from '@/components/GestionProveedoresCrudos.vue';
 import EntradasPorProveedorModal from '@/components/EntradasPorProveedorModal.vue';
+import RegistroCrudos from './RegistroCrudos.vue';
 import { formatNumber } from '@/utils/formatters';
 
 export default {
   name: 'ExistenciasCrudos',
   components: {
     GestionProveedoresCrudos,
-    EntradasPorProveedorModal
+    EntradasPorProveedorModal,
+    RegistroCrudos
   },
   data() {
     return {
@@ -273,6 +285,10 @@ export default {
         abierto: false,
         producto: null,
         movimientos: []
+      },
+      modalSalida: {
+        abierto: false,
+        registroId: null
       }
     };
   },
@@ -689,17 +705,25 @@ export default {
     },
 
     editRegistro(id) {
-      this.$router.push(`/existencias-crudos/${id}`);
+      this.modalSalida = { abierto: true, registroId: id };
     },
 
     irASalidaDeHoy() {
       const hoy = moment().startOf('day');
       const registroHoy = this.registros.find(registro => moment(registro.fecha).isSame(hoy, 'day'));
-      if (registroHoy) {
-        this.$router.push(`/existencias-crudos/${registroHoy.id}`);
-      } else {
-        this.$router.push('/existencias-crudos/new');
-      }
+      this.modalSalida = { abierto: true, registroId: registroHoy ? registroHoy.id : null };
+    },
+
+    cerrarModalSalida() {
+      this.modalSalida = { abierto: false, registroId: null };
+    },
+
+    async onSalidaGuardada() {
+      this.cerrarModalSalida();
+      await Promise.all([
+        this.loadRegistros(),
+        this.loadExistencias()
+      ]);
     },
 
     async deleteRegistro(id) {

--- a/src/views/ExistenciasCrudos.vue
+++ b/src/views/ExistenciasCrudos.vue
@@ -253,6 +253,7 @@ import GestionProveedoresCrudos from '@/components/GestionProveedoresCrudos.vue'
 import EntradasPorProveedorModal from '@/components/EntradasPorProveedorModal.vue';
 import RegistroCrudos from './RegistroCrudos.vue';
 import { formatNumber } from '@/utils/formatters';
+import { useUIStore } from '@/stores/ui';
 
 export default {
   name: 'ExistenciasCrudos',
@@ -706,16 +707,19 @@ export default {
 
     editRegistro(id) {
       this.modalSalida = { abierto: true, registroId: id };
+      useUIStore().openModal('salida-crudo');
     },
 
     irASalidaDeHoy() {
       const hoy = moment().startOf('day');
       const registroHoy = this.registros.find(registro => moment(registro.fecha).isSame(hoy, 'day'));
       this.modalSalida = { abierto: true, registroId: registroHoy ? registroHoy.id : null };
+      useUIStore().openModal('salida-crudo');
     },
 
     cerrarModalSalida() {
       this.modalSalida = { abierto: false, registroId: null };
+      useUIStore().closeModal();
     },
 
     async onSalidaGuardada() {
@@ -1025,6 +1029,11 @@ export default {
       this.loadExistencias(),
       this.loadProveedoresRegistrados()
     ]);
+  },
+
+  beforeDestroy() {
+    // Evitar que el navbar quede oculto si se navega fuera con el modal abierto
+    useUIStore().closeModal();
   }
 };
 </script>

--- a/src/views/ExistenciasCrudos.vue
+++ b/src/views/ExistenciasCrudos.vue
@@ -2,6 +2,16 @@
   <div class="existencias-crudos-container">
     <h1>Existencias de Crudos</h1>
     
+    <button
+      @click="irASalidaDeHoy"
+      :disabled="isLoadingRegistros"
+      class="quick-salida-btn"
+      title="Ir directo al registro de hoy para agregar una salida"
+    >
+      <i class="fas fa-bolt"></i>
+      Registrar Salida de Hoy
+    </button>
+
     <div class="actions-container">
       <router-link to="/existencias-crudos/new" class="action-button new-entrada-btn">
         Nueva Entrada/Salida
@@ -682,6 +692,16 @@ export default {
       this.$router.push(`/existencias-crudos/${id}`);
     },
 
+    irASalidaDeHoy() {
+      const hoy = moment().startOf('day');
+      const registroHoy = this.registros.find(registro => moment(registro.fecha).isSame(hoy, 'day'));
+      if (registroHoy) {
+        this.$router.push(`/existencias-crudos/${registroHoy.id}`);
+      } else {
+        this.$router.push('/existencias-crudos/new');
+      }
+    },
+
     async deleteRegistro(id) {
       // Obtener los datos del registro (estado local o Firestore) para el respaldo y el detalle
       let datosRegistro = this.registros.find(registro => registro.id === id) || null;
@@ -998,6 +1018,37 @@ export default {
 
 h1, h2, h3 {
   color: #3760b0;
+}
+
+.quick-salida-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  width: 100%;
+  background: linear-gradient(135deg, #ff9800, #f57c00);
+  color: white;
+  border: none;
+  padding: 16px 24px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 18px;
+  font-weight: bold;
+  margin-bottom: 20px;
+  box-shadow: 0 4px 8px rgba(245, 124, 0, 0.35);
+  transition: background 0.3s, transform 0.15s;
+}
+
+.quick-salida-btn:hover {
+  background: linear-gradient(135deg, #fb8c00, #ef6c00);
+  transform: translateY(-1px);
+}
+
+.quick-salida-btn:disabled {
+  background: #ccc;
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
 }
 
 .actions-container {

--- a/src/views/Procesos/PedidosCrudo.vue
+++ b/src/views/Procesos/PedidosCrudo.vue
@@ -127,7 +127,7 @@ export default {
     return {
       fecha: new Date().toISOString().split('T')[0],
       clientes: ['8a', 'Catarro', 'Otilio', 'Ozuna', 'Veronica'],
-      columnasBase: ['Med', 'Med-Esp', 'Med-gde', 'Gde', 'Extra'],
+      columnasBase: ['Med', 'Med-Esp', 'Med-gde', 'Gde', 'Extra', 'Jumbo', 'Cam s/c'],
       columnasAdicionales: [],
       nuevaColumna: '',
       pedidos: {},

--- a/src/views/Procesos/PedidosCrudo.vue
+++ b/src/views/Procesos/PedidosCrudo.vue
@@ -479,7 +479,7 @@ export default {
 
 <style scoped>
 .pedidos-crudo-container {
-  max-width: 800px;
+  max-width: 1200px;
   margin: 0 auto;
   padding: 20px;
   font-size: 16px;

--- a/src/views/RegistroCrudos.vue
+++ b/src/views/RegistroCrudos.vue
@@ -4,14 +4,23 @@
       <BackButton to="/existencias-crudos" />
     </div>
     <div v-else class="modal-header-modal">
-      <router-link
-        v-if="registroId"
-        :to="`/existencias-crudos/${registroId}`"
-        class="link-dia-completo"
-      >
-        Ver día completo (entradas y comparación)
-      </router-link>
-      <span v-else></span>
+      <div class="modal-header-left">
+        <button
+          v-if="entradas.length > 0"
+          type="button"
+          class="toggle-entradas-btn"
+          @click="mostrarEntradasEnModal = !mostrarEntradasEnModal"
+        >
+          {{ mostrarEntradasEnModal ? 'Ocultar Entradas' : `Ver Entradas (${entradas.length})` }}
+        </button>
+        <router-link
+          v-if="registroId"
+          :to="`/existencias-crudos/${registroId}`"
+          class="link-dia-completo"
+        >
+          Ver día completo
+        </router-link>
+      </div>
       <button type="button" class="close-modal-btn" @click="cerrarModal" title="Cerrar">&times;</button>
     </div>
     <h2 class="date-header">{{ formattedDate }}</h2>
@@ -20,7 +29,7 @@
     </div>
 
     <div class="registro-content" :class="{ 'solo-salidas': modoModal }">
-      <div v-if="!modoModal" class="entradas-section">
+      <div v-if="!modoModal || mostrarEntradasEnModal" class="entradas-section">
         <h3>Entradas de Crudos</h3>
         <div class="form-section">
           <div class="input-group">
@@ -374,7 +383,8 @@ export default {
       embarquesCargados: false,
       embarquesDelDia: [],
       crudosEmbarque: [],
-      salidasIniciales: 0
+      salidasIniciales: 0,
+      mostrarEntradasEnModal: false
     };
   },
   computed: {
@@ -1225,6 +1235,30 @@ export default {
   align-items: center;
   margin-bottom: 10px;
   gap: 10px;
+  flex-wrap: wrap;
+}
+
+.modal-header-left {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.toggle-entradas-btn {
+  background-color: #3760b0;
+  color: white;
+  border: none;
+  padding: 8px 14px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.9em;
+  font-weight: bold;
+  transition: background-color 0.3s;
+}
+
+.toggle-entradas-btn:hover {
+  background-color: #2a4a87;
 }
 
 .link-dia-completo {

--- a/src/views/RegistroCrudos.vue
+++ b/src/views/RegistroCrudos.vue
@@ -1062,6 +1062,9 @@ export default {
             items.forEach(item => {
               const nombre = item.talla || item.medida;
               if (!nombre) return;
+              // "Cam s/c" aquí representa piojo, que se descuenta de las
+              // existencias de limpios (Sacadas), no de las de crudos.
+              if (this.esCamSinCabeza(nombre)) return;
               agregar(nombre, this.kilosDeCrudoItem(item), cliente.nombre, this.esNombreMacuil(nombre));
             });
           });
@@ -1124,6 +1127,10 @@ export default {
 
     esNombreMacuil(nombre) {
       return this.normalizarNombreComparacion(nombre).includes('macuil');
+    },
+
+    esCamSinCabeza(nombre) {
+      return this.normalizarNombreComparacion(nombre) === 'cam s/c';
     }
   },
 

--- a/src/views/RegistroCrudos.vue
+++ b/src/views/RegistroCrudos.vue
@@ -204,47 +204,46 @@
             para el {{ formattedDate }}<span v-if="descripcionEmbarques"> ({{ descripcionEmbarques }})</span>.
             <button @click="cargarEmbarquesDelDia" class="btn-recargar">Actualizar</button>
           </p>
-          <div v-if="!comparacion.filas.length" class="no-productos">
+          <div v-if="comparacion.totalEmbarcado <= 0" class="no-productos">
             El embarque no tiene crudos ni macuil registrados.
           </div>
-          <div v-else class="comparacion-tabla-wrapper">
-            <table class="comparacion-tabla">
-              <thead>
-                <tr>
-                  <th>Producto del embarque</th>
-                  <th>Embarcado</th>
-                  <th>Salidas registradas</th>
-                  <th>Estado</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr v-for="fila in comparacion.filas" :key="fila.clave" :class="'estado-' + fila.estado">
-                  <td>
-                    {{ fila.nombre }}
-                    <span v-if="fila.clientes.length" class="clientes-info">({{ fila.clientes.join(', ') }})</span>
-                  </td>
-                  <td>{{ formatNumber(fila.kilos) }} kg</td>
-                  <td>{{ formatNumber(fila.kilosSalida) }} kg</td>
-                  <td>
-                    <span class="estado-icono">{{ fila.estado === 'ok' ? '✓' : (fila.estado === 'faltante' ? '✗' : '⚠') }}</span>
-                    {{ fila.estadoTexto }}
-                  </td>
-                </tr>
-              </tbody>
-            </table>
+          <div v-else>
+            <div class="comparacion-totales">
+              <div class="total-card">
+                <span class="total-etiqueta">Crudos embarcados</span>
+                <span class="total-valor">{{ formatNumber(comparacion.totalCrudos) }} kg</span>
+              </div>
+              <div v-if="comparacion.totalMacuil > 0" class="total-card">
+                <span class="total-etiqueta">Macuil embarcado (cocido)</span>
+                <span class="total-valor">{{ formatNumber(comparacion.totalMacuil) }} kg</span>
+              </div>
+              <div class="total-card">
+                <span class="total-etiqueta">Total embarcado</span>
+                <span class="total-valor">{{ formatNumber(comparacion.totalEmbarcado) }} kg</span>
+              </div>
+              <div class="total-card">
+                <span class="total-etiqueta">Salidas registradas del día</span>
+                <span class="total-valor">{{ formatNumber(comparacion.totalSalidas) }} kg</span>
+              </div>
+            </div>
+            <p class="comparacion-estado" :class="'estado-' + comparacion.estado">
+              <span class="estado-icono">{{ comparacion.estado === 'ok' ? '✓' : (comparacion.estado === 'faltante' ? '✗' : '⚠') }}</span>
+              {{ comparacion.estadoTexto }}
+            </p>
+            <div v-if="comparacion.desglose.length" class="sin-correspondencia">
+              <h4>Desglose de lo embarcado</h4>
+              <ul>
+                <li v-for="item in comparacion.desglose" :key="item.clave">
+                  {{ item.nombre }}: {{ formatNumber(item.kilos) }} kg
+                  <span v-if="item.clientes.length" class="clientes-info">({{ item.clientes.join(', ') }})</span>
+                </li>
+              </ul>
+            </div>
+            <p v-if="comparacion.totalMacuil > 0" class="comparacion-nota">
+              ℹ️ El macuil es camarón con cabeza cocido: las salidas de crudo del día deben
+              <strong>superar</strong> el total embarcado por la merma de cocción.
+            </p>
           </div>
-          <div v-if="comparacion.sinCorrespondencia.length" class="sin-correspondencia">
-            <h4>Salidas de hoy sin correspondencia en el embarque</h4>
-            <ul>
-              <li v-for="(salida, index) in comparacion.sinCorrespondencia" :key="'sc-' + index">
-                {{ salida.producto }}: {{ formatNumber(salida.kilos) }} kg
-              </li>
-            </ul>
-          </div>
-          <p class="comparacion-nota">
-            ℹ️ El macuil es camarón con cabeza cocido: la salida de crudo debe ser
-            <strong>mayor</strong> que los kilos embarcados por la merma de cocción.
-          </p>
         </div>
       </div>
     </div>
@@ -412,68 +411,59 @@ export default {
         .join(', ');
     },
     comparacion() {
-      // Agrupar las salidas registradas hoy por nombre normalizado de producto
-      const salidasAgrupadas = {};
-      this.salidas.forEach(salida => {
-        const clave = this.normalizarNombreComparacion(salida.producto);
-        if (!clave) return;
-        if (!salidasAgrupadas[clave]) {
-          salidasAgrupadas[clave] = { producto: salida.producto, kilos: 0 };
-        }
-        salidasAgrupadas[clave].kilos += Number(salida.kilos) || 0;
-      });
+      // Comparación por kilos totales del día: los nombres de producto varían
+      // por proveedor, así que no se cruza por nombre.
+      const totalCrudos = Number(
+        this.crudosEmbarque
+          .filter(item => !item.esMacuil)
+          .reduce((total, item) => total + item.kilos, 0)
+          .toFixed(1)
+      );
+      const totalMacuil = Number(
+        this.crudosEmbarque
+          .filter(item => item.esMacuil)
+          .reduce((total, item) => total + item.kilos, 0)
+          .toFixed(1)
+      );
+      const totalEmbarcado = Number((totalCrudos + totalMacuil).toFixed(1));
+      const totalSalidas = this.totalSalidas;
+      const diferencia = Number((totalSalidas - totalEmbarcado).toFixed(1));
 
-      const clavesUsadas = new Set();
-      const filas = this.crudosEmbarque.map(item => {
-        let kilosSalida = 0;
-        Object.keys(salidasAgrupadas).forEach(claveSalida => {
-          if (this.coincideNombre(item, claveSalida)) {
-            kilosSalida += salidasAgrupadas[claveSalida].kilos;
-            clavesUsadas.add(claveSalida);
-          }
-        });
-        kilosSalida = Number(kilosSalida.toFixed(1));
-        const diferencia = Number((kilosSalida - item.kilos).toFixed(1));
-
-        let estado;
-        let estadoTexto;
-        if (kilosSalida <= 0) {
-          estado = 'faltante';
-          estadoTexto = 'Sin salida registrada';
-        } else if (item.esMacuil) {
-          if (diferencia > 0) {
-            const merma = ((diferencia / kilosSalida) * 100).toFixed(1);
-            estado = 'ok';
-            estadoTexto = `Registrada con merma de ${formatNumber(diferencia)} kg (${merma}%)`;
-          } else {
-            estado = 'revisar';
-            estadoTexto = 'La salida debería ser mayor que lo embarcado (merma de cocción)';
-          }
+      let estado;
+      let estadoTexto;
+      if (totalSalidas <= 0) {
+        estado = 'faltante';
+        estadoTexto = 'No hay salidas registradas para este día';
+      } else if (totalMacuil > 0) {
+        if (diferencia > 0) {
+          const crudoParaMacuil = Number((totalMacuil + diferencia).toFixed(1));
+          const merma = ((diferencia / crudoParaMacuil) * 100).toFixed(1);
+          estado = 'ok';
+          estadoTexto = `Las salidas cubren lo embarcado, con merma de cocción del macuil de ${formatNumber(diferencia)} kg (${merma}%)`;
         } else {
-          const tolerancia = Math.max(0.5, item.kilos * 0.01);
-          if (Math.abs(diferencia) <= tolerancia) {
-            estado = 'ok';
-            estadoTexto = 'Registrada';
-          } else if (diferencia < 0) {
-            estado = 'revisar';
-            estadoTexto = `Faltan ${formatNumber(Math.abs(diferencia))} kg por registrar`;
-          } else {
-            estado = 'revisar';
-            estadoTexto = `Salida mayor que lo embarcado por ${formatNumber(diferencia)} kg`;
-          }
+          estado = 'revisar';
+          estadoTexto = `Las salidas deberían superar lo embarcado por la merma de cocción del macuil; faltan al menos ${formatNumber(Math.abs(diferencia))} kg por registrar`;
         }
+      } else {
+        const tolerancia = Math.max(0.5, totalEmbarcado * 0.01);
+        if (Math.abs(diferencia) <= tolerancia) {
+          estado = 'ok';
+          estadoTexto = 'Las salidas del día cuadran con lo embarcado';
+        } else if (diferencia < 0) {
+          estado = 'revisar';
+          estadoTexto = `Faltan ${formatNumber(Math.abs(diferencia))} kg de salidas por registrar`;
+        } else {
+          estado = 'revisar';
+          estadoTexto = `Las salidas superan lo embarcado por ${formatNumber(diferencia)} kg`;
+        }
+      }
 
-        return { ...item, kilosSalida, diferencia, estado, estadoTexto };
+      const desglose = [...this.crudosEmbarque].sort((a, b) => {
+        if (a.esMacuil !== b.esMacuil) return a.esMacuil ? 1 : -1;
+        return b.kilos - a.kilos;
       });
 
-      const sinCorrespondencia = Object.keys(salidasAgrupadas)
-        .filter(clave => !clavesUsadas.has(clave))
-        .map(clave => ({
-          producto: salidasAgrupadas[clave].producto,
-          kilos: Number(salidasAgrupadas[clave].kilos.toFixed(1))
-        }));
-
-      return { filas, sinCorrespondencia };
+      return { totalCrudos, totalMacuil, totalEmbarcado, totalSalidas, diferencia, estado, estadoTexto, desglose };
     },
     medidasDelProveedorEntrada() {
       if (!this.newEntrada.proveedor || this.newEntrada.proveedor === '__nuevo__') {
@@ -1134,26 +1124,6 @@ export default {
 
     esNombreMacuil(nombre) {
       return this.normalizarNombreComparacion(nombre).includes('macuil');
-    },
-
-    extraerRango(texto) {
-      const match = String(texto).match(/(\d+)\s*\/\s*(\d+)/);
-      return match ? `${match[1]}/${match[2]}` : null;
-    },
-
-    coincideNombre(itemEmbarque, claveSalida) {
-      const esSalidaMacuil = claveSalida.includes('macuil');
-      if (itemEmbarque.esMacuil) return esSalidaMacuil;
-      if (esSalidaMacuil) return false;
-
-      const claveItem = itemEmbarque.clave;
-      if (claveItem === claveSalida) return true;
-
-      const rangoItem = this.extraerRango(claveItem);
-      const rangoSalida = this.extraerRango(claveSalida);
-      if (rangoItem && rangoSalida) return rangoItem === rangoSalida;
-
-      return claveItem.includes(claveSalida) || claveSalida.includes(claveItem);
     }
   },
 
@@ -1545,60 +1515,63 @@ h3 {
   font-size: 13px;
 }
 
-.comparacion-tabla-wrapper {
-  overflow-x: auto;
+.comparacion-totales {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 10px;
+  margin-bottom: 15px;
 }
 
-.comparacion-tabla {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: 14px;
+.total-card {
+  background-color: #f8f9fa;
+  border-left: 4px solid #3760b0;
+  border-radius: 6px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
 }
 
-.comparacion-tabla th,
-.comparacion-tabla td {
-  padding: 10px;
-  text-align: left;
-  border-bottom: 1px solid #e9ecef;
+.total-etiqueta {
+  color: #666;
+  font-size: 13px;
 }
 
-.comparacion-tabla th {
-  background-color: #f0f4f8;
+.total-valor {
   color: #3760b0;
+  font-weight: bold;
+  font-size: 18px;
 }
 
-.comparacion-tabla .clientes-info {
+.comparacion-estado {
+  padding: 12px;
+  border-radius: 6px;
+  font-weight: bold;
+  font-size: 15px;
+}
+
+.comparacion-estado .estado-icono {
+  margin-right: 6px;
+}
+
+.comparacion-estado.estado-ok {
+  background-color: #f4fff6;
+  color: #1e7e34;
+}
+
+.comparacion-estado.estado-revisar {
+  background-color: #fff8e6;
+  color: #9c6f00;
+}
+
+.comparacion-estado.estado-faltante {
+  background-color: #fff1f0;
+  color: #c62828;
+}
+
+.clientes-info {
   color: #666;
   font-size: 12px;
-}
-
-.comparacion-tabla .estado-icono {
-  font-weight: bold;
-  margin-right: 4px;
-}
-
-.comparacion-tabla tr.estado-ok td {
-  background-color: #f4fff6;
-}
-
-.comparacion-tabla tr.estado-ok .estado-icono {
-  color: #28a745;
-}
-
-.comparacion-tabla tr.estado-revisar td {
-  background-color: #fff8e6;
-}
-
-.comparacion-tabla tr.estado-revisar .estado-icono {
-  color: #e6a700;
-}
-
-.comparacion-tabla tr.estado-faltante td {
-  background-color: #fff1f0;
-}
-
-.comparacion-tabla tr.estado-faltante .estado-icono {
-  color: #f44336;
 }
 
 .sin-correspondencia {

--- a/src/views/RegistroCrudos.vue
+++ b/src/views/RegistroCrudos.vue
@@ -1,15 +1,26 @@
 <template>
-  <div class="registro-crudos-container" v-if="isLoaded">
-    <div class="back-button-container">
+  <div class="registro-crudos-container" :class="{ 'modo-modal': modoModal }" v-if="isLoaded">
+    <div v-if="!modoModal" class="back-button-container">
       <BackButton to="/existencias-crudos" />
     </div>
+    <div v-else class="modal-header-modal">
+      <router-link
+        v-if="registroId"
+        :to="`/existencias-crudos/${registroId}`"
+        class="link-dia-completo"
+      >
+        Ver día completo (entradas y comparación)
+      </router-link>
+      <span v-else></span>
+      <button type="button" class="close-modal-btn" @click="cerrarModal" title="Cerrar">&times;</button>
+    </div>
     <h2 class="date-header">{{ formattedDate }}</h2>
-    <div class="date-selector">
+    <div v-if="!modoModal" class="date-selector">
       <input type="date" v-model="selectedDate" @change="updateCurrentDate">
     </div>
-    
-    <div class="registro-content">
-      <div class="entradas-section">
+
+    <div class="registro-content" :class="{ 'solo-salidas': modoModal }">
+      <div v-if="!modoModal" class="entradas-section">
         <h3>Entradas de Crudos</h3>
         <div class="form-section">
           <div class="input-group">
@@ -183,7 +194,7 @@
       </div>
     </div>
 
-    <div class="comparacion-embarque">
+    <div v-if="!modoModal" class="comparacion-embarque">
       <div class="comparacion-header" @click="toggleComparacion">
         <h3>
           Comparar salidas con embarque del día
@@ -255,7 +266,10 @@
       <p>Diferencia: {{ formatNumber(totalEntradas - totalSalidas) }} kg</p>
     </div>
     
-    <button @click="saveReport" class="save-button" :disabled="guardando">{{ guardando ? 'Guardando...' : (isEditing ? 'Actualizar' : 'Guardar') + ' Registro' }}</button>
+    <div class="save-actions" :class="{ 'save-actions-modal': modoModal }">
+      <button @click="saveReport" class="save-button" :disabled="guardando">{{ guardando ? 'Guardando...' : (isEditing ? 'Actualizar' : 'Guardar') + ' Registro' }}</button>
+      <button v-if="modoModal" @click="cerrarModal" class="cancel-modal-button" type="button">Cerrar sin guardar</button>
+    </div>
 
     <!-- Modal edición entrada -->
     <div v-if="editandoEntrada" class="modal-overlay" @click.self="cancelarEdicionEntrada">
@@ -310,6 +324,16 @@ export default {
   components: {
     BackButton
   },
+  props: {
+    modoModal: {
+      type: Boolean,
+      default: false
+    },
+    registroIdProp: {
+      type: String,
+      default: null
+    }
+  },
   data() {
     return {
       currentDate: moment(),
@@ -349,7 +373,8 @@ export default {
       cargandoEmbarques: false,
       embarquesCargados: false,
       embarquesDelDia: [],
-      crudosEmbarque: []
+      crudosEmbarque: [],
+      salidasIniciales: 0
     };
   },
   computed: {
@@ -916,6 +941,7 @@ export default {
         this.registroId = id;
         this.isEditing = true;
         this.fechaOriginal = this.currentDate.format('YYYY-MM-DD');
+        this.salidasIniciales = this.salidas.length;
         await this.loadProductosDisponibles();
       } else {
         console.log("No se encontró el documento con ID:", id);
@@ -971,19 +997,35 @@ export default {
 
         if (this.isEditing) {
           await updateDoc(doc(db, 'existenciasCrudos', this.registroId), reportData);
-          alert("Registro de crudos actualizado exitosamente");
+          if (!this.modoModal) alert("Registro de crudos actualizado exitosamente");
         } else {
-          await addDoc(collection(db, 'existenciasCrudos'), reportData);
-          alert("Registro de crudos guardado exitosamente");
+          const docRef = await addDoc(collection(db, 'existenciasCrudos'), reportData);
+          this.registroId = docRef.id;
+          this.isEditing = true;
+          this.fechaOriginal = this.currentDate.format('YYYY-MM-DD');
+          if (!this.modoModal) alert("Registro de crudos guardado exitosamente");
         }
-        
-        this.$router.push('/existencias-crudos');
+        this.salidasIniciales = this.salidas.length;
+
+        if (this.modoModal) {
+          this.$emit('guardado', this.registroId);
+        } else {
+          this.$router.push('/existencias-crudos');
+        }
       } catch (error) {
         console.error("Error al guardar/actualizar el registro: ", error);
         alert("Error al guardar/actualizar el registro: " + error.message);
       } finally {
         this.guardando = false;
       }
+    },
+
+    cerrarModal() {
+      const hayCambiosSinGuardar = this.salidas.length !== this.salidasIniciales;
+      if (hayCambiosSinGuardar && !confirm('Hay salidas sin guardar. ¿Cerrar de todas formas?')) {
+        return;
+      }
+      this.$emit('cerrar');
     },
 
     updateCurrentDate() {
@@ -1146,11 +1188,12 @@ export default {
       this.loadMedidasCrudos()
     ]);
     await this.loadProductosDisponibles();
-    
-    if (this.$route.params.id) {
-      await this.loadRegistro(this.$route.params.id);
+
+    const idAEditar = this.modoModal ? this.registroIdProp : this.$route.params.id;
+    if (idAEditar) {
+      await this.loadRegistro(idAEditar);
     }
-    
+
     this.isLoaded = true;
   }
 };
@@ -1168,6 +1211,40 @@ export default {
 
 .back-button-container {
   margin-bottom: 20px;
+}
+
+.registro-crudos-container.modo-modal {
+  max-width: 900px;
+  max-height: 90vh;
+  overflow-y: auto;
+}
+
+.modal-header-modal {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 10px;
+  gap: 10px;
+}
+
+.link-dia-completo {
+  color: #3760b0;
+  font-weight: bold;
+  text-decoration: underline;
+}
+
+.close-modal-btn {
+  background: transparent;
+  border: none;
+  font-size: 1.8em;
+  line-height: 1;
+  color: #666;
+  cursor: pointer;
+  padding: 0 6px;
+}
+
+.close-modal-btn:hover {
+  color: #000;
 }
 
 .date-header {
@@ -1194,6 +1271,10 @@ export default {
   grid-template-columns: 1fr 1fr;
   gap: 30px;
   margin-bottom: 30px;
+}
+
+.registro-content.solo-salidas {
+  grid-template-columns: 1fr;
 }
 
 .entradas-section,
@@ -1627,6 +1708,14 @@ h3 {
   font-size: 16px;
 }
 
+.save-actions {
+  display: flex;
+}
+
+.save-actions-modal {
+  gap: 10px;
+}
+
 .save-button {
   display: block;
   width: 100%;
@@ -1638,6 +1727,22 @@ h3 {
   border-radius: 8px;
   cursor: pointer;
   transition: background-color 0.3s;
+}
+
+.cancel-modal-button {
+  padding: 15px 20px;
+  font-size: 1.05em;
+  background-color: #6c757d;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background-color 0.3s;
+  white-space: nowrap;
+}
+
+.cancel-modal-button:hover {
+  background-color: #565e64;
 }
 
 .save-button:hover {

--- a/src/views/RegistroCrudos.vue
+++ b/src/views/RegistroCrudos.vue
@@ -182,7 +182,73 @@
         <p class="total">Total Salidas: {{ formatNumber(totalSalidas) }} kg</p>
       </div>
     </div>
-    
+
+    <div class="comparacion-embarque">
+      <div class="comparacion-header" @click="toggleComparacion">
+        <h3>
+          Comparar salidas con embarque del día
+          <span class="toggle-icon">{{ comparacionVisible ? '▲' : '▼' }}</span>
+        </h3>
+      </div>
+      <div v-if="comparacionVisible" class="comparacion-body">
+        <div v-if="cargandoEmbarques" class="comparacion-cargando">
+          Buscando embarque del {{ formattedDate }}...
+        </div>
+        <div v-else-if="!embarquesDelDia.length" class="no-productos">
+          No se encontró ningún embarque para el {{ formattedDate }}.
+          <button @click="cargarEmbarquesDelDia" class="btn-recargar">Volver a buscar</button>
+        </div>
+        <div v-else>
+          <p class="comparacion-info">
+            {{ embarquesDelDia.length === 1 ? 'Embarque encontrado' : embarquesDelDia.length + ' embarques encontrados' }}
+            para el {{ formattedDate }}<span v-if="descripcionEmbarques"> ({{ descripcionEmbarques }})</span>.
+            <button @click="cargarEmbarquesDelDia" class="btn-recargar">Actualizar</button>
+          </p>
+          <div v-if="!comparacion.filas.length" class="no-productos">
+            El embarque no tiene crudos ni macuil registrados.
+          </div>
+          <div v-else class="comparacion-tabla-wrapper">
+            <table class="comparacion-tabla">
+              <thead>
+                <tr>
+                  <th>Producto del embarque</th>
+                  <th>Embarcado</th>
+                  <th>Salidas registradas</th>
+                  <th>Estado</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="fila in comparacion.filas" :key="fila.clave" :class="'estado-' + fila.estado">
+                  <td>
+                    {{ fila.nombre }}
+                    <span v-if="fila.clientes.length" class="clientes-info">({{ fila.clientes.join(', ') }})</span>
+                  </td>
+                  <td>{{ formatNumber(fila.kilos) }} kg</td>
+                  <td>{{ formatNumber(fila.kilosSalida) }} kg</td>
+                  <td>
+                    <span class="estado-icono">{{ fila.estado === 'ok' ? '✓' : (fila.estado === 'faltante' ? '✗' : '⚠') }}</span>
+                    {{ fila.estadoTexto }}
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <div v-if="comparacion.sinCorrespondencia.length" class="sin-correspondencia">
+            <h4>Salidas de hoy sin correspondencia en el embarque</h4>
+            <ul>
+              <li v-for="(salida, index) in comparacion.sinCorrespondencia" :key="'sc-' + index">
+                {{ salida.producto }}: {{ formatNumber(salida.kilos) }} kg
+              </li>
+            </ul>
+          </div>
+          <p class="comparacion-nota">
+            ℹ️ El macuil es camarón con cabeza cocido: la salida de crudo debe ser
+            <strong>mayor</strong> que los kilos embarcados por la merma de cocción.
+          </p>
+        </div>
+      </div>
+    </div>
+
     <div class="summary">
       <h3>Resumen del Día</h3>
       <p>Total Entradas: {{ formatNumber(totalEntradas) }} kg</p>
@@ -238,6 +304,7 @@ import { collection, addDoc, getDocs, doc, getDoc, updateDoc, query, where } fro
 import BackButton from '../components/BackButton.vue';
 import moment from 'moment';
 import { formatNumber } from '@/utils/formatters';
+import { normalizarFechaValor } from '@/utils/dateUtils';
 
 export default {
   name: 'RegistroCrudos',
@@ -278,7 +345,12 @@ export default {
       kilosDisponiblesSeleccionados: 0,
       editandoEntrada: false,
       entradaEditIndex: null,
-      entradaEditData: { kilos: null, cuartoFrio: '' }
+      entradaEditData: { kilos: null, cuartoFrio: '' },
+      comparacionVisible: false,
+      cargandoEmbarques: false,
+      embarquesCargados: false,
+      embarquesDelDia: [],
+      crudosEmbarque: []
     };
   },
   computed: {
@@ -332,6 +404,76 @@ export default {
       );
       if (!productoSel || !productoSel.cuartos) return [];
       return productoSel.cuartos.map(c => c.nombre);
+    },
+    descripcionEmbarques() {
+      return this.embarquesDelDia
+        .map(e => e.descripcion)
+        .filter(Boolean)
+        .join(', ');
+    },
+    comparacion() {
+      // Agrupar las salidas registradas hoy por nombre normalizado de producto
+      const salidasAgrupadas = {};
+      this.salidas.forEach(salida => {
+        const clave = this.normalizarNombreComparacion(salida.producto);
+        if (!clave) return;
+        if (!salidasAgrupadas[clave]) {
+          salidasAgrupadas[clave] = { producto: salida.producto, kilos: 0 };
+        }
+        salidasAgrupadas[clave].kilos += Number(salida.kilos) || 0;
+      });
+
+      const clavesUsadas = new Set();
+      const filas = this.crudosEmbarque.map(item => {
+        let kilosSalida = 0;
+        Object.keys(salidasAgrupadas).forEach(claveSalida => {
+          if (this.coincideNombre(item, claveSalida)) {
+            kilosSalida += salidasAgrupadas[claveSalida].kilos;
+            clavesUsadas.add(claveSalida);
+          }
+        });
+        kilosSalida = Number(kilosSalida.toFixed(1));
+        const diferencia = Number((kilosSalida - item.kilos).toFixed(1));
+
+        let estado;
+        let estadoTexto;
+        if (kilosSalida <= 0) {
+          estado = 'faltante';
+          estadoTexto = 'Sin salida registrada';
+        } else if (item.esMacuil) {
+          if (diferencia > 0) {
+            const merma = ((diferencia / kilosSalida) * 100).toFixed(1);
+            estado = 'ok';
+            estadoTexto = `Registrada con merma de ${formatNumber(diferencia)} kg (${merma}%)`;
+          } else {
+            estado = 'revisar';
+            estadoTexto = 'La salida debería ser mayor que lo embarcado (merma de cocción)';
+          }
+        } else {
+          const tolerancia = Math.max(0.5, item.kilos * 0.01);
+          if (Math.abs(diferencia) <= tolerancia) {
+            estado = 'ok';
+            estadoTexto = 'Registrada';
+          } else if (diferencia < 0) {
+            estado = 'revisar';
+            estadoTexto = `Faltan ${formatNumber(Math.abs(diferencia))} kg por registrar`;
+          } else {
+            estado = 'revisar';
+            estadoTexto = `Salida mayor que lo embarcado por ${formatNumber(diferencia)} kg`;
+          }
+        }
+
+        return { ...item, kilosSalida, diferencia, estado, estadoTexto };
+      });
+
+      const sinCorrespondencia = Object.keys(salidasAgrupadas)
+        .filter(clave => !clavesUsadas.has(clave))
+        .map(clave => ({
+          producto: salidasAgrupadas[clave].producto,
+          kilos: Number(salidasAgrupadas[clave].kilos.toFixed(1))
+        }));
+
+      return { filas, sinCorrespondencia };
     },
     medidasDelProveedorEntrada() {
       if (!this.newEntrada.proveedor || this.newEntrada.proveedor === '__nuevo__') {
@@ -857,6 +999,161 @@ export default {
     updateCurrentDate() {
       this.currentDate = moment(this.selectedDate);
       this.loadProductosDisponibles();
+      this.embarquesCargados = false;
+      this.embarquesDelDia = [];
+      this.crudosEmbarque = [];
+      if (this.comparacionVisible) {
+        this.cargarEmbarquesDelDia();
+      }
+    },
+
+    async toggleComparacion() {
+      this.comparacionVisible = !this.comparacionVisible;
+      if (this.comparacionVisible && !this.embarquesCargados && !this.cargandoEmbarques) {
+        await this.cargarEmbarquesDelDia();
+      }
+    },
+
+    async cargarEmbarquesDelDia() {
+      this.cargandoEmbarques = true;
+      try {
+        const objetivo = this.currentDate.format('YYYY-MM-DD');
+        // La fecha de los embarques se guarda en formatos heterogéneos
+        // (Timestamp, Date o string), por lo que se filtra en cliente.
+        const snapshot = await getDocs(collection(db, 'embarques'));
+        const embarques = [];
+        snapshot.docs.forEach(docSnap => {
+          const data = docSnap.data();
+          const fecha = normalizarFechaValor(data.fecha || data.fechaRegistro);
+          if (fecha === objetivo) {
+            embarques.push({ id: docSnap.id, ...data });
+          }
+        });
+
+        this.embarquesDelDia = embarques.map(e => ({
+          id: e.id,
+          descripcion: [e.cargaCon ? `carga con ${e.cargaCon}` : '', e.borrador ? 'borrador' : '']
+            .filter(Boolean)
+            .join(', ')
+        }));
+        this.crudosEmbarque = this.extraerCrudosDeEmbarques(embarques);
+        this.embarquesCargados = true;
+      } catch (error) {
+        console.error('Error al cargar embarques del día:', error);
+        alert('Error al cargar el embarque del día: ' + error.message);
+      } finally {
+        this.cargandoEmbarques = false;
+      }
+    },
+
+    extraerCrudosDeEmbarques(embarques) {
+      const acumulado = {};
+      const agregar = (nombre, kilos, cliente, esMacuil) => {
+        if (!kilos || kilos <= 0) return;
+        const clave = esMacuil ? 'macuil' : this.normalizarNombreComparacion(nombre);
+        if (!clave) return;
+        if (!acumulado[clave]) {
+          acumulado[clave] = {
+            clave,
+            nombre: esMacuil ? 'Macuil (cocido)' : nombre,
+            kilos: 0,
+            esMacuil,
+            clientes: new Set()
+          };
+        }
+        acumulado[clave].kilos = Number((acumulado[clave].kilos + kilos).toFixed(1));
+        if (cliente) acumulado[clave].clientes.add(cliente);
+      };
+
+      embarques.forEach(embarque => {
+        const pesoTaraVenta = Number(embarque.pesoTaraVenta) || 20;
+        (embarque.clientes || []).forEach(cliente => {
+          (cliente.crudos || []).forEach(grupo => {
+            const items = grupo && grupo.items ? grupo.items : [];
+            items.forEach(item => {
+              const nombre = item.talla || item.medida;
+              if (!nombre) return;
+              agregar(nombre, this.kilosDeCrudoItem(item, pesoTaraVenta), cliente.nombre, this.esNombreMacuil(nombre));
+            });
+          });
+          // El macuil viaja como producto limpio (camarón c/cabeza cocido),
+          // pero su salida se registra como crudo con merma de cocción.
+          (cliente.productos || []).forEach(producto => {
+            if (!this.esNombreMacuil(producto.medida)) return;
+            agregar(producto.medida, this.kilosNetosProducto(producto), cliente.nombre, true);
+          });
+        });
+      });
+
+      return Object.values(acumulado).map(item => ({
+        ...item,
+        clientes: Array.from(item.clientes)
+      }));
+    },
+
+    kilosDeCrudoItem(item, pesoTaraVenta) {
+      const parsear = (valor) => {
+        if (!valor) return 0;
+        const match = String(valor).trim().match(/^(\d+)\s*-\s*(\d+(?:\.\d+)?)$/);
+        if (!match) return 0;
+        const cantidad = Number(match[1]);
+        let peso = Number(match[2]);
+        // Misma regla que en Embarques: las taras capturadas a 19 se venden a peso de venta
+        if (peso === 19) peso = pesoTaraVenta;
+        return cantidad * peso;
+      };
+      return Number((parsear(item.taras) + parsear(item.sobrante)).toFixed(1));
+    },
+
+    kilosNetosProducto(producto) {
+      if (!producto) return 0;
+      if (producto.tipo === 'c/h20') {
+        const reporteTaras = producto.reporteTaras || [];
+        const reporteBolsas = producto.reporteBolsas || [];
+        let totalBolsas = 0;
+        reporteTaras.forEach((tara, i) => {
+          totalBolsas += (Number(tara) || 0) * (Number(reporteBolsas[i]) || 0);
+        });
+        return Number((totalBolsas * (Number(producto.camaronNeto) || 0.65)).toFixed(1));
+      }
+      const sumaKilos = (producto.kilos || []).reduce((s, k) => s + (Number(k) || 0), 0);
+      const totalTaras = (producto.taras || []).reduce((s, t) => s + (Number(t) || 0), 0)
+        + (producto.tarasExtra || []).reduce((s, t) => s + (Number(t) || 0), 0);
+      const descuento = producto.restarTaras !== false ? totalTaras * 3 : 0;
+      return Number(Math.max(sumaKilos - descuento, 0).toFixed(1));
+    },
+
+    normalizarNombreComparacion(nombre) {
+      return String(nombre || '')
+        .toLowerCase()
+        .normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .replace(/\s+/g, ' ')
+        .trim();
+    },
+
+    esNombreMacuil(nombre) {
+      return this.normalizarNombreComparacion(nombre).includes('macuil');
+    },
+
+    extraerRango(texto) {
+      const match = String(texto).match(/(\d+)\s*\/\s*(\d+)/);
+      return match ? `${match[1]}/${match[2]}` : null;
+    },
+
+    coincideNombre(itemEmbarque, claveSalida) {
+      const esSalidaMacuil = claveSalida.includes('macuil');
+      if (itemEmbarque.esMacuil) return esSalidaMacuil;
+      if (esSalidaMacuil) return false;
+
+      const claveItem = itemEmbarque.clave;
+      if (claveItem === claveSalida) return true;
+
+      const rangoItem = this.extraerRango(claveItem);
+      const rangoSalida = this.extraerRango(claveSalida);
+      if (rangoItem && rangoSalida) return rangoItem === rangoSalida;
+
+      return claveItem.includes(claveSalida) || claveSalida.includes(claveItem);
     }
   },
 
@@ -1201,6 +1498,135 @@ h3 {
   padding: 10px;
   background-color: #f0f4f8;
   border-radius: 6px;
+}
+
+.comparacion-embarque {
+  background-color: white;
+  border-radius: 10px;
+  padding: 20px;
+  margin-bottom: 20px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.comparacion-header {
+  cursor: pointer;
+}
+
+.comparacion-header h3 {
+  margin-bottom: 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.comparacion-header .toggle-icon {
+  font-size: 0.8em;
+}
+
+.comparacion-body {
+  margin-top: 20px;
+}
+
+.comparacion-cargando {
+  text-align: center;
+  color: #3760b0;
+  padding: 20px;
+  font-style: italic;
+}
+
+.comparacion-info {
+  color: #3760b0;
+  margin-bottom: 15px;
+}
+
+.btn-recargar {
+  margin-left: 10px;
+  padding: 5px 10px;
+  font-size: 13px;
+}
+
+.comparacion-tabla-wrapper {
+  overflow-x: auto;
+}
+
+.comparacion-tabla {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+
+.comparacion-tabla th,
+.comparacion-tabla td {
+  padding: 10px;
+  text-align: left;
+  border-bottom: 1px solid #e9ecef;
+}
+
+.comparacion-tabla th {
+  background-color: #f0f4f8;
+  color: #3760b0;
+}
+
+.comparacion-tabla .clientes-info {
+  color: #666;
+  font-size: 12px;
+}
+
+.comparacion-tabla .estado-icono {
+  font-weight: bold;
+  margin-right: 4px;
+}
+
+.comparacion-tabla tr.estado-ok td {
+  background-color: #f4fff6;
+}
+
+.comparacion-tabla tr.estado-ok .estado-icono {
+  color: #28a745;
+}
+
+.comparacion-tabla tr.estado-revisar td {
+  background-color: #fff8e6;
+}
+
+.comparacion-tabla tr.estado-revisar .estado-icono {
+  color: #e6a700;
+}
+
+.comparacion-tabla tr.estado-faltante td {
+  background-color: #fff1f0;
+}
+
+.comparacion-tabla tr.estado-faltante .estado-icono {
+  color: #f44336;
+}
+
+.sin-correspondencia {
+  margin-top: 15px;
+  padding: 12px;
+  background-color: #f8f9fa;
+  border-radius: 6px;
+}
+
+.sin-correspondencia h4 {
+  color: #3760b0;
+  margin: 0 0 8px 0;
+  font-size: 14px;
+}
+
+.sin-correspondencia ul {
+  margin: 0;
+  padding-left: 20px;
+}
+
+.comparacion-nota {
+  margin-top: 15px;
+  padding: 10px;
+  background-color: #f0f8ff;
+  border-left: 4px solid #3760b0;
+  border-radius: 4px;
+  font-size: 13px;
+  color: #333;
 }
 
 .summary {

--- a/src/views/RegistroCrudos.vue
+++ b/src/views/RegistroCrudos.vue
@@ -5,14 +5,24 @@
     </div>
     <div v-else class="modal-header-modal">
       <div class="modal-header-left">
-        <button
-          v-if="entradas.length > 0"
-          type="button"
-          class="toggle-entradas-btn"
-          @click="mostrarEntradasEnModal = !mostrarEntradasEnModal"
-        >
-          {{ mostrarEntradasEnModal ? 'Ocultar Entradas' : `Ver Entradas (${entradas.length})` }}
-        </button>
+        <div class="modal-tabs">
+          <button
+            type="button"
+            class="modal-tab-btn"
+            :class="{ active: pestanaModal === 'entradas' }"
+            @click="pestanaModal = 'entradas'"
+          >
+            Entradas{{ entradas.length > 0 ? ` (${entradas.length})` : '' }}
+          </button>
+          <button
+            type="button"
+            class="modal-tab-btn"
+            :class="{ active: pestanaModal === 'salidas' }"
+            @click="pestanaModal = 'salidas'"
+          >
+            Salidas{{ salidas.length > 0 ? ` (${salidas.length})` : '' }}
+          </button>
+        </div>
         <router-link
           v-if="registroId"
           :to="`/existencias-crudos/${registroId}`"
@@ -29,7 +39,7 @@
     </div>
 
     <div class="registro-content" :class="{ 'solo-salidas': modoModal }">
-      <div v-if="!modoModal || mostrarEntradasEnModal" class="entradas-section">
+      <div v-if="!modoModal || pestanaModal === 'entradas'" class="entradas-section">
         <h3>Entradas de Crudos</h3>
         <div class="form-section">
           <div class="input-group">
@@ -127,7 +137,7 @@
         <p class="total">Total Entradas: {{ formatNumber(totalEntradas) }} kg</p>
       </div>
       
-      <div class="salidas-section">
+      <div v-if="!modoModal || pestanaModal === 'salidas'" class="salidas-section">
         <h3>Salidas de Crudos</h3>
         <div class="form-section">
           <div class="input-group">
@@ -384,7 +394,7 @@ export default {
       embarquesDelDia: [],
       crudosEmbarque: [],
       salidasIniciales: 0,
-      mostrarEntradasEnModal: false
+      pestanaModal: 'salidas'
     };
   },
   computed: {
@@ -1245,20 +1255,33 @@ export default {
   flex-wrap: wrap;
 }
 
-.toggle-entradas-btn {
-  background-color: #3760b0;
-  color: white;
+.modal-tabs {
+  display: flex;
+  gap: 6px;
+  background-color: #dbe6f5;
+  padding: 4px;
+  border-radius: 8px;
+}
+
+.modal-tab-btn {
+  background-color: transparent;
+  color: #3760b0;
   border: none;
-  padding: 8px 14px;
+  padding: 8px 16px;
   border-radius: 6px;
   cursor: pointer;
   font-size: 0.9em;
   font-weight: bold;
-  transition: background-color 0.3s;
+  transition: background-color 0.3s, color 0.3s;
 }
 
-.toggle-entradas-btn:hover {
-  background-color: #2a4a87;
+.modal-tab-btn:hover {
+  background-color: rgba(55, 96, 176, 0.15);
+}
+
+.modal-tab-btn.active {
+  background-color: #3760b0;
+  color: white;
 }
 
 .link-dia-completo {

--- a/src/views/RegistroCrudos.vue
+++ b/src/views/RegistroCrudos.vue
@@ -1056,14 +1056,13 @@ export default {
       };
 
       embarques.forEach(embarque => {
-        const pesoTaraVenta = Number(embarque.pesoTaraVenta) || 20;
         (embarque.clientes || []).forEach(cliente => {
           (cliente.crudos || []).forEach(grupo => {
             const items = grupo && grupo.items ? grupo.items : [];
             items.forEach(item => {
               const nombre = item.talla || item.medida;
               if (!nombre) return;
-              agregar(nombre, this.kilosDeCrudoItem(item, pesoTaraVenta), cliente.nombre, this.esNombreMacuil(nombre));
+              agregar(nombre, this.kilosDeCrudoItem(item), cliente.nombre, this.esNombreMacuil(nombre));
             });
           });
           // El macuil viaja como producto limpio (camarón c/cabeza cocido),
@@ -1081,16 +1080,17 @@ export default {
       }));
     },
 
-    kilosDeCrudoItem(item, pesoTaraVenta) {
+    kilosDeCrudoItem(item) {
+      // Para comparar contra las salidas se usa el peso real de la tara (19 kg),
+      // no el peso de venta que aplica el módulo de embarques.
       const parsear = (valor) => {
         if (!valor) return 0;
-        const match = String(valor).trim().match(/^(\d+)\s*-\s*(\d+(?:\.\d+)?)$/);
-        if (!match) return 0;
-        const cantidad = Number(match[1]);
-        let peso = Number(match[2]);
-        // Misma regla que en Embarques: las taras capturadas a 19 se venden a peso de venta
-        if (peso === 19) peso = pesoTaraVenta;
-        return cantidad * peso;
+        const texto = String(valor).trim();
+        const conPeso = texto.match(/^(\d+)\s*-\s*(\d+(?:\.\d+)?)$/);
+        if (conPeso) return Number(conPeso[1]) * 19;
+        const soloCantidad = texto.match(/^(\d+)$/);
+        if (soloCantidad) return Number(soloCantidad[1]) * 19;
+        return 0;
       };
       return Number((parsear(item.taras) + parsear(item.sobrante)).toFixed(1));
     },

--- a/src/views/Sacadas.vue
+++ b/src/views/Sacadas.vue
@@ -1819,14 +1819,14 @@ export default {
       return Number(total.toFixed(1));
     },
     kilosDeTaraCrudo(valor) {
-      // El peso real de una tara de crudo es 19 kg, independientemente del
-      // peso capturado en el string (que puede reflejar el peso de venta).
+      // A diferencia de las existencias de crudos (19 kg reales por tara),
+      // en limpios el kilaje de venta de estas taras se calcula a 20 kg.
       if (!valor) return 0;
       const texto = String(valor).trim();
       const conPeso = texto.match(/^(\d+)\s*-\s*(\d+(?:\.\d+)?)$/);
-      if (conPeso) return Number(conPeso[1]) * 19;
+      if (conPeso) return Number(conPeso[1]) * 20;
       const soloCantidad = texto.match(/^(\d+)$/);
-      if (soloCantidad) return Number(soloCantidad[1]) * 19;
+      if (soloCantidad) return Number(soloCantidad[1]) * 20;
       return 0;
     },
     fechaEmbarqueAYMD(valor) {
@@ -1948,13 +1948,15 @@ export default {
 
           // "Cam s/c" en los crudos del embarque representa piojo, que se
           // descuenta de las existencias de limpios (aquí en Sacadas), no de
-          // las de crudos. Se suma como kilos esperados de "Piojo".
+          // las de crudos. Se suma aparte, con una firma propia que no se
+          // confunde con una salida de "Piojo" normal/no relacionada.
           const kilosPiojo = this.kilosCamSinCabezaDeEmbarque(emb);
           if (kilosPiojo > 0) {
-            const clavePiojo = this.firmaDeRendimiento('Piojo');
+            const medidaPiojoCamSC = 'Piojo (Cam s/c)';
+            const clavePiojo = this.firmaDeRendimiento(medidaPiojoCamSC);
             if (clavePiojo) {
               if (!acumulado[clavePiojo]) {
-                acumulado[clavePiojo] = { medida: 'Piojo', kilos: 0 };
+                acumulado[clavePiojo] = { medida: medidaPiojoCamSC, kilos: 0 };
               }
               acumulado[clavePiojo].kilos += kilosPiojo;
             }

--- a/src/views/Sacadas.vue
+++ b/src/views/Sacadas.vue
@@ -1948,15 +1948,16 @@ export default {
 
           // "Cam s/c" en los crudos del embarque representa piojo, que se
           // descuenta de las existencias de limpios (aquí en Sacadas), no de
-          // las de crudos. Se suma aparte, con una firma propia que no se
-          // confunde con una salida de "Piojo" normal/no relacionada.
+          // las de crudos. Se suma a la misma firma que cualquier salida de
+          // "Piojo" normal (sin importar el proveedor), para que reconcilie
+          // contra lo ya registrado; si nadie ha registrado nada todavía se
+          // muestra como "Piojo (Cam s/c)" para dejar claro su origen.
           const kilosPiojo = this.kilosCamSinCabezaDeEmbarque(emb);
           if (kilosPiojo > 0) {
-            const medidaPiojoCamSC = 'Piojo (Cam s/c)';
-            const clavePiojo = this.firmaDeRendimiento(medidaPiojoCamSC);
+            const clavePiojo = this.firmaDeRendimiento('Piojo');
             if (clavePiojo) {
               if (!acumulado[clavePiojo]) {
-                acumulado[clavePiojo] = { medida: medidaPiojoCamSC, kilos: 0 };
+                acumulado[clavePiojo] = { medida: 'Piojo (Cam s/c)', kilos: 0 };
               }
               acumulado[clavePiojo].kilos += kilosPiojo;
             }

--- a/src/views/Sacadas.vue
+++ b/src/views/Sacadas.vue
@@ -1803,6 +1803,32 @@ export default {
       }
       return this.buildMedidaSignature(texto);
     },
+    kilosCamSinCabezaDeEmbarque(embarque) {
+      let total = 0;
+      const clientes = Array.isArray(embarque?.clientes) ? embarque.clientes : [];
+      clientes.forEach(cliente => {
+        (cliente.crudos || []).forEach(grupo => {
+          const items = grupo && grupo.items ? grupo.items : [];
+          items.forEach(item => {
+            const nombre = String(item.talla || item.medida || '').trim().toLowerCase();
+            if (nombre !== 'cam s/c') return;
+            total += this.kilosDeTaraCrudo(item.taras) + this.kilosDeTaraCrudo(item.sobrante);
+          });
+        });
+      });
+      return Number(total.toFixed(1));
+    },
+    kilosDeTaraCrudo(valor) {
+      // El peso real de una tara de crudo es 19 kg, independientemente del
+      // peso capturado en el string (que puede reflejar el peso de venta).
+      if (!valor) return 0;
+      const texto = String(valor).trim();
+      const conPeso = texto.match(/^(\d+)\s*-\s*(\d+(?:\.\d+)?)$/);
+      if (conPeso) return Number(conPeso[1]) * 19;
+      const soloCantidad = texto.match(/^(\d+)$/);
+      if (soloCantidad) return Number(soloCantidad[1]) * 19;
+      return 0;
+    },
     fechaEmbarqueAYMD(valor) {
       if (!valor) return null;
       let fecha = null;
@@ -1919,6 +1945,20 @@ export default {
             }
             acumulado[clave].kilos += kilos;
           });
+
+          // "Cam s/c" en los crudos del embarque representa piojo, que se
+          // descuenta de las existencias de limpios (aquí en Sacadas), no de
+          // las de crudos. Se suma como kilos esperados de "Piojo".
+          const kilosPiojo = this.kilosCamSinCabezaDeEmbarque(emb);
+          if (kilosPiojo > 0) {
+            const clavePiojo = this.firmaDeRendimiento('Piojo');
+            if (clavePiojo) {
+              if (!acumulado[clavePiojo]) {
+                acumulado[clavePiojo] = { medida: 'Piojo', kilos: 0 };
+              }
+              acumulado[clavePiojo].kilos += kilosPiojo;
+            }
+          }
         });
 
         this.kilosCrudosPorMedida = acumulado;

--- a/src/views/Sacadas.vue
+++ b/src/views/Sacadas.vue
@@ -1,11 +1,41 @@
 <template>
-  <div class="sacadas-container" v-if="isLoaded">
-    <div class="back-button-container">
+  <div class="sacadas-container" :class="{ 'modo-modal': modoModal }" v-if="isLoaded">
+    <div v-if="!modoModal" class="back-button-container">
       <BackButton to="/sacadas" />
       <button v-if="tienePedidoOrigen" @click="regresarAlPedido" class="btn-regresar-pedido">Regresar al Pedido</button>
     </div>
+    <div v-else class="modal-header-modal">
+      <div class="modal-header-left">
+        <div class="modal-tabs">
+          <button
+            type="button"
+            class="modal-tab-btn"
+            :class="{ active: pestanaModal === 'entradas' }"
+            @click="pestanaModal = 'entradas'"
+          >
+            Entradas{{ entradas.length > 0 ? ` (${entradas.length})` : '' }}
+          </button>
+          <button
+            type="button"
+            class="modal-tab-btn"
+            :class="{ active: pestanaModal === 'salidas' }"
+            @click="pestanaModal = 'salidas'"
+          >
+            Salidas{{ salidas.length > 0 ? ` (${salidas.length})` : '' }}
+          </button>
+        </div>
+        <router-link
+          v-if="sacadaId"
+          :to="`/sacadas/${sacadaId}`"
+          class="link-dia-completo"
+        >
+          Ver día completo
+        </router-link>
+      </div>
+      <button type="button" class="close-modal-btn" @click="cerrarModal" title="Cerrar">&times;</button>
+    </div>
     <h2 class="date-header">{{ formattedDate }}</h2>
-    <div class="date-selector-row">
+    <div v-if="!modoModal" class="date-selector-row">
       <div class="date-selector">
         <input type="date" v-model="selectedDate" @change="updateCurrentDate">
       </div>
@@ -13,8 +43,8 @@
         Medidas a sacar
       </button>
     </div>
-    <div class="sacadas-content">
-      <div class="salidas-section">
+    <div class="sacadas-content" :class="{ 'solo-una-seccion': modoModal }">
+      <div v-if="!modoModal || pestanaModal === 'salidas'" class="salidas-section">
         <h3>Salidas</h3>
         <div class="input-group">
           <select v-model="newSalida.tipo" required @change="resetSalidaSelections">
@@ -84,7 +114,7 @@
         <p class="total">Total Salidas: {{ formatNumber(totalSalidas) }} kg</p>
       </div>
       
-      <div class="entradas-section">
+      <div v-if="!modoModal || pestanaModal === 'entradas'" class="entradas-section">
         <h3>Entradas</h3>
         <div class="input-group">
           <select v-model="newEntrada.tipo" required @change="resetEntradaSelections">
@@ -162,7 +192,7 @@
       </div>
     </div>
     
-    <div class="summary">
+    <div v-if="!modoModal" class="summary">
       <h3>Resumen del Día</h3>
       <p>Total Entradas: {{ formatNumber(totalEntradas) }} kg</p>
       <p>Total Salidas: {{ formatNumber(totalSalidas) }} kg</p>
@@ -249,7 +279,7 @@
       </table>
     </div>
 
-    <div class="auditoria-section">
+    <div v-if="!modoModal" class="auditoria-section">
       <div class="auditoria-header">
         <button
           type="button"
@@ -348,7 +378,10 @@
       </div>
     </div>
 
-    <button @click="saveReport" class="save-button" :disabled="guardando">{{ guardando ? 'Guardando...' : (isEditing ? 'Actualizar' : 'Guardar') + ' Informe del Día' }}</button>
+    <div class="save-actions" :class="{ 'save-actions-modal': modoModal }">
+      <button @click="saveReport" class="save-button" :disabled="guardando">{{ guardando ? 'Guardando...' : (isEditing ? 'Actualizar' : 'Guardar') + ' Informe del Día' }}</button>
+      <button v-if="modoModal" @click="cerrarModal" class="cancel-modal-button" type="button">Cerrar sin guardar</button>
+    </div>
     
     <!-- Modal de Edición de Entrada -->
     <div v-if="editandoEntrada" class="modal-overlay" @click.self="cancelarEdicionEntrada">
@@ -447,6 +480,16 @@ export default {
     ListaMedidasPedidoModal,
     MedidasParaHoyCards
   },
+  props: {
+    modoModal: {
+      type: Boolean,
+      default: false
+    },
+    sacadaIdProp: {
+      type: String,
+      default: null
+    }
+  },
   data() {
     return {
       currentDate: moment(),
@@ -483,7 +526,9 @@ export default {
       embarquesAnalizadosAuditoria: 0,
       auditoriaCargada: false,
       auditoriaToleranciaKg: 0.5,
-      auditoriaOkChecklist: {}
+      auditoriaOkChecklist: {},
+      pestanaModal: 'salidas',
+      salidasIniciales: 0
     };
   },
   computed: {
@@ -1376,6 +1421,7 @@ export default {
         this.sacadaId = id;
         this.isEditing = true;
         this.fechaOriginal = this.currentDate.format('YYYY-MM-DD');
+        this.salidasIniciales = this.salidas.length;
         this.limpiarChecklistSalidas();
         await this.updateKilosDisponibles();
       }
@@ -1411,13 +1457,22 @@ export default {
 
         if (this.isEditing) {
           await updateDoc(doc(db, 'sacadas', this.sacadaId), reportData);
-          alert("Informe del día actualizado exitosamente");
+          if (!this.modoModal) alert("Informe del día actualizado exitosamente");
         } else {
-          await addDoc(collection(db, 'sacadas'), reportData);
-          alert("Informe del día guardado exitosamente");
+          const docRef = await addDoc(collection(db, 'sacadas'), reportData);
+          this.sacadaId = docRef.id;
+          this.isEditing = true;
+          this.fechaOriginal = this.currentDate.format('YYYY-MM-DD');
+          if (!this.modoModal) alert("Informe del día guardado exitosamente");
         }
+        this.salidasIniciales = this.salidas.length;
         this.invalidarCacheSacadas();
-        this.$router.push('/sacadas');
+
+        if (this.modoModal) {
+          this.$emit('guardado', this.sacadaId);
+        } else {
+          this.$router.push('/sacadas');
+        }
       } catch (error) {
         console.error("Error al guardar/actualizar el documento: ", error);
         alert("Error al guardar/actualizar el informe del día: " + error.message);
@@ -1427,6 +1482,13 @@ export default {
     },
     updateCurrentDate() {
       this.currentDate = moment(this.selectedDate);
+    },
+    cerrarModal() {
+      const hayCambiosSinGuardar = this.salidas.length !== this.salidasIniciales;
+      if (hayCambiosSinGuardar && !confirm('Hay salidas sin guardar. ¿Cerrar de todas formas?')) {
+        return;
+      }
+      this.$emit('cerrar');
     },
     async getMedidasConPrecio(proveedor) {
       const medidasDisponibles = new Map();
@@ -1995,14 +2057,15 @@ export default {
   },
   async created() {
     // Si viene fecha desde el pedido, usarla como seleccionada
-    if (this.$route.query && this.$route.query.fecha) {
+    if (!this.modoModal && this.$route.query && this.$route.query.fecha) {
       this.selectedDate = this.$route.query.fecha
       this.updateCurrentDate()
     }
     await this.loadProveedores();
     await this.loadMedidas();
-    if (this.$route.params.id) {
-      await this.loadSacada(this.$route.params.id);
+    const idAEditar = this.modoModal ? this.sacadaIdProp : this.$route.params.id;
+    if (idAEditar) {
+      await this.loadSacada(idAEditar);
     }
     this.isLoaded = true;
   },
@@ -2082,6 +2145,111 @@ export default {
   box-shadow:
     0 0 0 1px rgba(62, 248, 255, 0.15) inset,
     0 16px 40px rgba(3, 2, 20, 0.7);
+}
+
+.sacadas-container.modo-modal {
+  max-width: 900px;
+  max-height: 90vh;
+  overflow-y: auto;
+}
+
+.modal-header-modal {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 10px;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.modal-header-left {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.modal-tabs {
+  display: flex;
+  gap: 6px;
+  background: rgba(12, 16, 43, 0.85);
+  border: 1px solid rgba(62, 248, 255, 0.3);
+  padding: 4px;
+  border-radius: 999px;
+}
+
+.modal-tab-btn {
+  background: transparent;
+  color: var(--vw-soft);
+  border: none;
+  padding: 8px 16px;
+  border-radius: 999px;
+  cursor: pointer;
+  font-size: 0.9em;
+  font-weight: 600;
+  transition: background-color 0.3s, color 0.3s, box-shadow 0.3s;
+}
+
+.modal-tab-btn:hover {
+  color: var(--vw-text);
+}
+
+.modal-tab-btn.active {
+  background: linear-gradient(135deg, #3ef8ff, #2563eb);
+  color: #0f172a;
+  box-shadow: 0 0 14px rgba(62, 248, 255, 0.4);
+}
+
+.link-dia-completo {
+  color: var(--vw-neon-cyan);
+  font-weight: 600;
+  text-decoration: underline;
+}
+
+.close-modal-btn {
+  background: transparent;
+  border: none;
+  font-size: 1.8em;
+  line-height: 1;
+  color: var(--vw-soft);
+  cursor: pointer;
+  padding: 0 6px;
+}
+
+.close-modal-btn:hover {
+  color: var(--vw-text);
+}
+
+.sacadas-content.solo-una-seccion {
+  grid-template-columns: 1fr;
+}
+
+.save-actions {
+  display: flex;
+}
+
+.save-actions-modal {
+  gap: 10px;
+}
+
+.save-actions .save-button {
+  flex: 1;
+}
+
+.cancel-modal-button {
+  margin-top: 20px;
+  padding: 14px 22px;
+  font-size: 1em;
+  font-weight: 600;
+  background: linear-gradient(135deg, #64748b, #475569);
+  color: #ffffff;
+  border-radius: 999px;
+  white-space: nowrap;
+  box-shadow: 0 0 14px rgba(100, 116, 139, 0.3);
+}
+
+.cancel-modal-button:hover {
+  box-shadow: 0 0 20px rgba(100, 116, 139, 0.45);
 }
 
 .date-header {

--- a/src/views/SacadasMenu.vue
+++ b/src/views/SacadasMenu.vue
@@ -102,6 +102,7 @@ import HistorialProductoModal from '@/components/HistorialProductoModal.vue';
 import ListaMedidasPedidoModal from '@/components/ListaMedidasPedidoModal.vue';
 import Sacadas from './Sacadas.vue';
 import { formatNumber } from '@/utils/formatters';
+import { useUIStore } from '@/stores/ui';
 
 export default {
   name: 'SacadasMenu',
@@ -180,16 +181,19 @@ export default {
     },
     editSacada(id) {
       this.modalSalida = { abierto: true, sacadaId: id };
+      useUIStore().openModal('salida-sacada');
     },
 
     irASalidaDeHoy() {
       const hoy = moment().startOf('day');
       const sacadaHoy = this.sacadas.find(sacada => moment(sacada.fecha).isSame(hoy, 'day'));
       this.modalSalida = { abierto: true, sacadaId: sacadaHoy ? sacadaHoy.id : null };
+      useUIStore().openModal('salida-sacada');
     },
 
     cerrarModalSalida() {
       this.modalSalida = { abierto: false, sacadaId: null };
+      useUIStore().closeModal();
     },
 
     async onSalidaGuardada() {
@@ -321,6 +325,11 @@ export default {
       this.loadProveedores(),
       this.loadMedidas()
     ]);
+  },
+
+  beforeDestroy() {
+    // Evitar que el navbar quede oculto si se navega fuera con el modal abierto
+    useUIStore().closeModal();
   }
 };
 </script>

--- a/src/views/SacadasMenu.vue
+++ b/src/views/SacadasMenu.vue
@@ -1,7 +1,17 @@
 <template>
   <div class="sacadas-menu-container">
     <h1>Menú de Sacadas</h1>
-    
+
+    <button
+      @click="irASalidaDeHoy"
+      :disabled="isLoading"
+      class="quick-salida-btn"
+      title="Ir directo al registro de hoy para agregar una salida"
+    >
+      <i class="fas fa-bolt"></i>
+      Registrar Salida de Hoy
+    </button>
+
     <div class="actions-container">
       <router-link to="/sacadas/new" class="action-button new-sacada-btn">
         Nueva Sacada
@@ -70,6 +80,16 @@
       @medida-created="loadMedidas"
       @medida-deleted="loadMedidas"
     />
+
+    <!-- Modal rápido: solo entradas/salidas del día -->
+    <div v-if="modalSalida.abierto" class="modal-overlay" @click.self="cerrarModalSalida">
+      <Sacadas
+        modo-modal
+        :sacada-id-prop="modalSalida.sacadaId"
+        @guardado="onSalidaGuardada"
+        @cerrar="cerrarModalSalida"
+      />
+    </div>
   </div>
 </template>
 
@@ -80,13 +100,15 @@ import moment from 'moment'; // Import Moment.js
 import PapeleraService from '@/services/PapeleraService';
 import HistorialProductoModal from '@/components/HistorialProductoModal.vue';
 import ListaMedidasPedidoModal from '@/components/ListaMedidasPedidoModal.vue';
+import Sacadas from './Sacadas.vue';
 import { formatNumber } from '@/utils/formatters';
 
 export default {
   name: 'SacadasMenu',
   components: {
     HistorialProductoModal,
-    ListaMedidasPedidoModal
+    ListaMedidasPedidoModal,
+    Sacadas
   },
   data() {
     return {
@@ -99,7 +121,11 @@ export default {
       medidas: [],
       isListaMedidasModalOpen: false,
       selectedSacadaForMeasures: null,
-      isSavingListaMedidas: false
+      isSavingListaMedidas: false,
+      modalSalida: {
+        abierto: false,
+        sacadaId: null
+      }
     };
   },
   computed: {
@@ -153,7 +179,22 @@ export default {
       return moment(date).format('DD [de] MMMM [de] YYYY');
     },
     editSacada(id) {
-      this.$router.push(`/sacadas/${id}`);
+      this.modalSalida = { abierto: true, sacadaId: id };
+    },
+
+    irASalidaDeHoy() {
+      const hoy = moment().startOf('day');
+      const sacadaHoy = this.sacadas.find(sacada => moment(sacada.fecha).isSame(hoy, 'day'));
+      this.modalSalida = { abierto: true, sacadaId: sacadaHoy ? sacadaHoy.id : null };
+    },
+
+    cerrarModalSalida() {
+      this.modalSalida = { abierto: false, sacadaId: null };
+    },
+
+    async onSalidaGuardada() {
+      this.cerrarModalSalida();
+      await this.loadSacadas();
     },
     async deleteSacada(id) {
       // Obtener los datos del día (estado local o Firestore) para el respaldo y el detalle
@@ -316,6 +357,51 @@ h2 {
   font-size: 1.15rem;
   color: var(--vw-neon-purple);
   text-shadow: 0 0 8px rgba(168, 85, 247, 0.45);
+}
+
+.quick-salida-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  width: 100%;
+  background: linear-gradient(135deg, #ff9800, #f57c00);
+  color: white;
+  border: none;
+  padding: 16px 24px;
+  border-radius: 12px;
+  cursor: pointer;
+  font-size: 18px;
+  font-weight: bold;
+  margin-bottom: 16px;
+  box-shadow: 0 0 20px rgba(245, 124, 0, 0.4);
+  transition: box-shadow 0.3s, transform 0.15s;
+}
+
+.quick-salida-btn:hover {
+  box-shadow: 0 0 26px rgba(245, 124, 0, 0.55);
+  transform: translateY(-1px);
+}
+
+.quick-salida-btn:disabled {
+  background: #4b5563;
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
+}
+
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.6);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+  padding: 20px;
 }
 
 .actions-container {


### PR DESCRIPTION
## Summary
Adds a collapsible "Compare shipments with daily exits" section to the RegistroCrudos view that allows users to reconcile recorded product exits against shipment manifests for the same day.

## Key Changes

- **New UI Section**: Added `.comparacion-embarque` component with collapsible header that displays:
  - Loading state while fetching shipments
  - List of shipments found for the selected date with descriptions
  - Comparison table showing embarked vs. recorded quantities
  - Status indicators (✓ OK, ⚠ Review, ✗ Missing)
  - List of recorded exits with no corresponding shipment items
  - Informational note about macuil (cooked shrimp) shrinkage expectations

- **Data Loading**: 
  - `cargarEmbarquesDelDia()` fetches all shipments and filters by date using `normalizarFechaValor()` utility to handle heterogeneous date formats (Timestamp, Date, string)
  - `extraerCrudosDeEmbarques()` aggregates crude and macuil items from shipment manifests, handling both raw items and finished products

- **Comparison Logic**:
  - `comparacion` computed property matches recorded exits to shipment items by normalized product names
  - Handles special case for macuil (cooked product) where recorded exit should exceed embarked quantity due to cooking shrinkage
  - Calculates tolerance (±1% or 0.5 kg minimum) for non-macuil items
  - Identifies unmatched exits and missing registrations

- **Helper Methods**:
  - `normalizarNombreComparacion()` — normalizes product names for matching (lowercase, removes accents, trims whitespace)
  - `kilosDeCrudoItem()` — calculates net kilos from tara/sobrante counts
  - `kilosNetosProducto()` — extracts net weight from finished product records
  - `coincideNombre()` — matches shipment items to recorded exits with range-based fallback (e.g., "31/35" format)
  - `esNombreMacuil()` — identifies macuil products by name

- **State Management**: 
  - Added `comparacionVisible`, `cargandoEmbarques`, `embarquesCargados`, `embarquesDelDia`, `crudosEmbarque` to component data
  - Resets shipment data when date changes via `updateCurrentDate()`

- **Styling**: Added comprehensive CSS for table, status colors (green/yellow/red), loading state, and informational sections

## Notable Implementation Details

- Date filtering is done client-side because shipment dates are stored in heterogeneous formats (Firestore Timestamp, JS Date, or string)
- Macuil handling distinguishes between raw items (in `cliente.crudos`) and finished products (in `cliente.productos`) with different weight calculation methods
- Product name matching uses normalized comparison with fallback to range extraction for size-based products (e.g., "31/35" shrimp counts)
- Tolerance for non-macuil items is dynamic: max(0.5 kg, 1% of embarked quantity)

https://claude.ai/code/session_01RqBbgDwpWCXqa1rGtXxwj1