### PR TITLE
Análisis de Stock: recomendación de compra basada en salidas recientes

### DIFF
--- a/src/components/Existencias.vue
+++ b/src/components/Existencias.vue
@@ -3,9 +3,14 @@
     <div class="existencias-container">
       <div class="header">
         <h1>Reporte de Existencias</h1>
-        <button @click="imprimirReporte" class="print-button">
-          Imprimir Reporte
-        </button>
+        <div class="header-actions">
+          <router-link to="/analisis-stock" class="analisis-button">
+            📊 Análisis de Stock
+          </router-link>
+          <button @click="imprimirReporte" class="print-button">
+            Imprimir Reporte
+          </button>
+        </div>
       </div>
       
       <div class="filters">
@@ -1606,6 +1611,30 @@ h1 {
   color: #2c3e50;
   margin: 0;
   font-size: 24px;
+}
+
+.header-actions {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.analisis-button {
+  background-color: #8e44ad;
+  color: white;
+  border: none;
+  padding: 10px 20px;
+  border-radius: 5px;
+  cursor: pointer;
+  font-size: 16px;
+  text-decoration: none;
+  display: inline-block;
+  transition: background-color 0.3s ease;
+}
+
+.analisis-button:hover {
+  background-color: #7d3c98;
 }
 
 .print-button {

--- a/src/router.js
+++ b/src/router.js
@@ -11,6 +11,7 @@ import GestionarProductos from '@/components/GestionarProductos.vue'
 import GestionarMedidas from '@/components/GestionarMedidas.vue'
 import GestionarProveedores from '@/components/GestionarProveedores.vue'
 import Existencias from '@/components/Existencias.vue'
+import AnalisisStock from '@/views/AnalisisStock.vue'
 import CuentasMexico from '@/views/CuentasMexico.vue'
 import OzunaCuentasMenu from '@/views/CuentasClientes/OzunaCuentasMenu.vue'
 import CuentasOzuna from '@/views/CuentasClientes/CuentasOzuna.vue'
@@ -127,6 +128,11 @@ const routes = [
     path: '/existencias',
     name: 'Existencias',
     component: Existencias
+  },
+  {
+    path: '/analisis-stock',
+    name: 'AnalisisStock',
+    component: AnalisisStock
   },
   {
     path: '/existencias-crudos',

--- a/src/views/AnalisisStock.vue
+++ b/src/views/AnalisisStock.vue
@@ -28,7 +28,7 @@
           </label>
           <label>
             Proveedor
-            <select v-model="proveedorSeleccionado">
+            <select v-model="proveedorSeleccionado" @change="cargarMedidasProveedor">
               <option value="">Seleccionar proveedor</option>
               <option v-for="prov in proveedores" :key="prov" :value="prov">
                 {{ prov }}
@@ -52,6 +52,35 @@
           >
             {{ cargando ? 'Calculando...' : 'Calcular Distribución' }}
           </button>
+        </div>
+
+        <div class="medidas-selector">
+          <div class="medidas-selector-header">
+            <span>Medidas a incluir{{ proveedorSeleccionado ? ` — ${proveedorSeleccionado}` : '' }}</span>
+            <div v-if="medidasDisponibles.length > 0" class="medidas-selector-acciones">
+              <button type="button" @click="medidasSeleccionadas = medidasDisponibles.map(m => m.nombre)">
+                Todas
+              </button>
+              <button type="button" @click="medidasSeleccionadas = []">
+                Ninguna
+              </button>
+            </div>
+          </div>
+
+          <div v-if="cargandoMedidas" class="medidas-mensaje">Cargando medidas...</div>
+          <div v-else-if="!proveedorSeleccionado" class="medidas-mensaje">
+            Selecciona un proveedor para ver sus medidas disponibles.
+          </div>
+          <div v-else-if="medidasDisponibles.length === 0" class="medidas-mensaje">
+            No se encontraron medidas para este proveedor.
+          </div>
+          <div v-else class="medidas-checkbox-grid">
+            <label v-for="medida in medidasDisponibles" :key="medida.nombre" class="medida-checkbox">
+              <input type="checkbox" :value="medida.nombre" v-model="medidasSeleccionadas" />
+              <span class="medida-nombre">{{ medida.nombre }}</span>
+              <span class="medida-stock-hint">{{ formatNumber(medida.stockActual) }} kg</span>
+            </label>
+          </div>
         </div>
       </div>
 
@@ -142,6 +171,10 @@ export default {
       proveedorSeleccionado: '',
       diasHistorial: 30,
       proveedores: [],
+      proveedoresObjetos: [],
+      medidasDisponibles: [],
+      medidasSeleccionadas: [],
+      cargandoMedidas: false,
       cargando: false,
       error: '',
       resultado: null
@@ -151,7 +184,8 @@ export default {
     puedeCalcular() {
       return this.proveedorSeleccionado &&
              this.kilosDisponibles &&
-             this.kilosDisponibles > 0;
+             this.kilosDisponibles > 0 &&
+             this.medidasSeleccionadas.length > 0;
     }
   },
   methods: {
@@ -174,15 +208,145 @@ export default {
     async loadProveedores() {
       try {
         const querySnapshot = await getDocs(collection(db, 'proveedores'));
-        this.proveedores = querySnapshot.docs
-          .map(docItem => docItem.data())
+        this.proveedoresObjetos = querySnapshot.docs
+          .map(docItem => ({ id: docItem.id, ...docItem.data() }))
           .filter(p => p.tipo === 'proveedor' && p.nombre)
-          .map(p => p.nombre)
-          .sort((a, b) => a.localeCompare(b));
+          .sort((a, b) => a.nombre.localeCompare(b.nombre));
+        this.proveedores = this.proveedoresObjetos.map(p => p.nombre);
       } catch (error) {
         console.error('Error al cargar proveedores:', error);
+        this.proveedoresObjetos = [];
         this.proveedores = [];
       }
+    },
+
+    // Lee la colección 'sacadas' una vez y calcula, para el proveedor dado,
+    // el stock actual por medida (entradas - salidas de todo el histórico) y,
+    // si se pasan fechas, la demanda (salidas) dentro de ese periodo.
+    async obtenerMovimientosProveedor(proveedorNombre, fechaInicio, fechaFin) {
+      const snapshot = await getDocs(collection(db, 'sacadas'));
+      const demandaPorMedida = {};
+      const stockPorMedida = {};
+      let totalVendido = 0;
+
+      snapshot.docs.forEach(docSnap => {
+        const sacada = docSnap.data();
+        const fecha = this.parseFechaSacada(sacada.fecha);
+        if (!fecha) return;
+        const enPeriodo = fechaInicio && fechaFin
+          ? moment(fecha).isBetween(fechaInicio, fechaFin, undefined, '[]')
+          : false;
+
+        (sacada.entradas || []).forEach(entrada => {
+          if (!this.coincideProveedor(entrada.proveedor, proveedorNombre)) return;
+          const medida = String(entrada.medida || '').trim();
+          if (!medida) return;
+          stockPorMedida[medida] = (stockPorMedida[medida] || 0) + (Number(entrada.kilos) || 0);
+        });
+
+        (sacada.salidas || []).forEach(salida => {
+          if (!this.coincideProveedor(salida.proveedor, proveedorNombre)) return;
+          const medida = String(salida.medida || '').trim();
+          if (!medida) return;
+          const kilos = Number(salida.kilos) || 0;
+
+          stockPorMedida[medida] = (stockPorMedida[medida] || 0) - kilos;
+
+          if (enPeriodo && kilos > 0) {
+            demandaPorMedida[medida] = (demandaPorMedida[medida] || 0) + kilos;
+            totalVendido += kilos;
+          }
+        });
+      });
+
+      return { demandaPorMedida, stockPorMedida, totalVendido };
+    },
+
+    async cargarMedidasProveedor() {
+      this.medidasDisponibles = [];
+      this.medidasSeleccionadas = [];
+      this.resultado = null;
+      this.error = '';
+
+      if (!this.proveedorSeleccionado) return;
+
+      this.cargandoMedidas = true;
+      try {
+        const proveedorObj = this.proveedoresObjetos.find(p => p.nombre === this.proveedorSeleccionado);
+        const nombresCatalogo = new Set();
+
+        if (proveedorObj) {
+          const medidasSnapshot = await getDocs(collection(db, 'medidas'));
+          medidasSnapshot.docs.forEach(docSnap => {
+            const medida = docSnap.data();
+            if (medida.proveedorId === proveedorObj.id && medida.nombre) {
+              nombresCatalogo.add(String(medida.nombre).trim());
+            }
+          });
+        }
+
+        const { stockPorMedida } = await this.obtenerMovimientosProveedor(this.proveedorSeleccionado, null, null);
+        Object.keys(stockPorMedida).forEach(medida => nombresCatalogo.add(medida));
+
+        const lista = Array.from(nombresCatalogo)
+          .sort((a, b) => a.localeCompare(b, 'es', { numeric: true }))
+          .map(nombre => ({
+            nombre,
+            stockActual: Number((stockPorMedida[nombre] || 0).toFixed(1))
+          }));
+
+        this.medidasDisponibles = lista;
+        // Por default, seleccionar las medidas que tenemos en existencia actual
+        this.medidasSeleccionadas = lista.filter(m => m.stockActual > 1).map(m => m.nombre);
+      } catch (error) {
+        console.error('Error al cargar medidas del proveedor:', error);
+        this.medidasDisponibles = [];
+        this.medidasSeleccionadas = [];
+      } finally {
+        this.cargandoMedidas = false;
+      }
+    },
+
+    // Reparte totalKilos en bloques de "bloque" kg entre las filas, en
+    // proporción a su demanda, usando el método de restos mayores para que
+    // cada compra sea un múltiplo cerrado y la suma cuadre con totalKilos.
+    distribuirEnMultiplos(filas, totalKilos, bloque = 500) {
+      const totalBloques = Math.round(totalKilos / bloque);
+
+      if (filas.length === 0 || totalBloques <= 0) {
+        return filas.map(fila => ({ ...fila, compra: 0 }));
+      }
+
+      const totalDemanda = filas.reduce((sum, fila) => sum + fila.vendido, 0);
+
+      if (totalDemanda <= 0) {
+        const base = Math.floor(totalBloques / filas.length);
+        const resto = totalBloques % filas.length;
+        return filas.map((fila, index) => ({
+          ...fila,
+          compra: (base + (index < resto ? 1 : 0)) * bloque
+        }));
+      }
+
+      const conBloques = filas.map(fila => {
+        const exacto = (fila.vendido / totalDemanda) * totalBloques;
+        return { ...fila, bloquesExactos: exacto, bloques: Math.floor(exacto) };
+      });
+
+      const asignados = conBloques.reduce((sum, fila) => sum + fila.bloques, 0);
+      const restantes = totalBloques - asignados;
+
+      const ordenResiduo = [...conBloques].sort(
+        (a, b) => (b.bloquesExactos - b.bloques) - (a.bloquesExactos - a.bloques)
+      );
+      for (let i = 0; i < restantes; i += 1) {
+        ordenResiduo[i % ordenResiduo.length].bloques += 1;
+      }
+
+      return conBloques.map(({ bloquesExactos, bloques, ...resto }) => ({
+        ...resto,
+        compra: bloques * bloque
+      }));
     },
 
     async calcular() {
@@ -197,72 +361,39 @@ export default {
         const fechaInicio = moment().subtract(dias, 'days').startOf('day');
         const fechaFin = moment().endOf('day');
 
-        // Una sola lectura de la colección: sirve tanto para la demanda del
-        // periodo como para el stock actual (entradas - salidas de todo el
-        // histórico), igual que lo calcula la vista de Existencias.
-        const snapshot = await getDocs(collection(db, 'sacadas'));
+        const { demandaPorMedida, stockPorMedida } = await this.obtenerMovimientosProveedor(
+          proveedor, fechaInicio, fechaFin
+        );
 
-        const demandaPorMedida = {};
-        const stockPorMedida = {};
-        let totalVendido = 0;
-
-        snapshot.docs.forEach(docSnap => {
-          const sacada = docSnap.data();
-          const fecha = this.parseFechaSacada(sacada.fecha);
-          if (!fecha) return;
-          const enPeriodo = moment(fecha).isBetween(fechaInicio, fechaFin, undefined, '[]');
-
-          (sacada.entradas || []).forEach(entrada => {
-            if (!this.coincideProveedor(entrada.proveedor, proveedor)) return;
-            const medida = String(entrada.medida || '').trim();
-            if (!medida) return;
-            stockPorMedida[medida] = (stockPorMedida[medida] || 0) + (Number(entrada.kilos) || 0);
-          });
-
-          (sacada.salidas || []).forEach(salida => {
-            if (!this.coincideProveedor(salida.proveedor, proveedor)) return;
-            const medida = String(salida.medida || '').trim();
-            if (!medida) return;
-            const kilos = Number(salida.kilos) || 0;
-
-            stockPorMedida[medida] = (stockPorMedida[medida] || 0) - kilos;
-
-            if (enPeriodo && kilos > 0) {
-              demandaPorMedida[medida] = (demandaPorMedida[medida] || 0) + kilos;
-              totalVendido += kilos;
-            }
-          });
-        });
-
+        const seleccionadas = new Set(this.medidasSeleccionadas);
         const kilosAComprar = Number(this.kilosDisponibles) || 0;
 
-        // Distribuir proporcionalmente y absorber el residuo de redondeo en la
-        // medida de mayor demanda, para que la suma cuadre con lo disponible.
-        const filas = Object.entries(demandaPorMedida)
-          .map(([medida, vendido]) => {
-            const porcentaje = totalVendido > 0 ? (vendido / totalVendido) * 100 : 0;
+        const filasBase = Object.entries(demandaPorMedida)
+          .filter(([medida]) => seleccionadas.has(medida))
+          .map(([medida, vendido]) => ({ medida, vendido: Number(vendido.toFixed(1)) }));
+
+        const totalVendido = filasBase.reduce((sum, fila) => sum + fila.vendido, 0);
+
+        // Compra recomendada en múltiplos cerrados de 500 kg
+        const filas = this.distribuirEnMultiplos(filasBase, kilosAComprar, 500)
+          .map(fila => {
+            const stockActual = Number((stockPorMedida[fila.medida] || 0).toFixed(1));
             return {
-              medida,
-              vendido: Number(vendido.toFixed(1)),
-              porcentaje,
-              compra: Math.round(kilosAComprar * (porcentaje / 100)),
-              stockActual: Number((stockPorMedida[medida] || 0).toFixed(1))
+              medida: fila.medida,
+              vendido: fila.vendido,
+              porcentaje: totalVendido > 0 ? (fila.vendido / totalVendido) * 100 : 0,
+              compra: fila.compra,
+              stockActual,
+              stockPostCompra: Number((stockActual + fila.compra).toFixed(1))
             };
           })
           .sort((a, b) => b.vendido - a.vendido);
 
-        if (filas.length > 0) {
-          const sumaCompras = filas.reduce((sum, fila) => sum + fila.compra, 0);
-          filas[0].compra += kilosAComprar - sumaCompras;
-        }
-
-        filas.forEach(fila => {
-          fila.stockPostCompra = Number((fila.stockActual + fila.compra).toFixed(1));
-        });
-
-        const sinVentas = Object.entries(stockPorMedida)
-          .filter(([medida, kilos]) => !demandaPorMedida[medida] && kilos > 1)
-          .map(([medida, kilos]) => ({ medida, stockActual: Number(kilos.toFixed(1)) }))
+        // Medidas seleccionadas sin demanda en el periodo: no reciben compra,
+        // pero se muestran aparte para que no queden ocultas.
+        const sinVentas = this.medidasSeleccionadas
+          .filter(medida => !demandaPorMedida[medida])
+          .map(medida => ({ medida, stockActual: Number((stockPorMedida[medida] || 0).toFixed(1)) }))
           .sort((a, b) => b.stockActual - a.stockActual);
 
         this.resultado = {
@@ -271,7 +402,7 @@ export default {
           fechaInicio: fechaInicio.format('DD/MM/YYYY'),
           fechaFin: fechaFin.format('DD/MM/YYYY'),
           totalVendido: Number(totalVendido.toFixed(1)),
-          totalCompra: kilosAComprar,
+          totalCompra: filas.reduce((sum, fila) => sum + fila.compra, 0),
           totalStockActual: Number(
             filas.reduce((sum, fila) => sum + fila.stockActual, 0).toFixed(1)
           ),
@@ -375,6 +506,89 @@ h2 {
   border-radius: 5px;
   font-size: 16px;
   background-color: white;
+}
+
+.medidas-selector {
+  margin-top: 18px;
+  padding-top: 15px;
+  border-top: 1px solid #dee2e6;
+}
+
+.medidas-selector-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 10px;
+  font-weight: bold;
+  color: #2c3e50;
+  font-size: 14px;
+}
+
+.medidas-selector-acciones {
+  display: flex;
+  gap: 8px;
+}
+
+.medidas-selector-acciones button {
+  background: none;
+  border: 1px solid #3498db;
+  color: #3498db;
+  padding: 4px 10px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: bold;
+}
+
+.medidas-selector-acciones button:hover {
+  background-color: #3498db;
+  color: white;
+}
+
+.medidas-mensaje {
+  color: #666;
+  font-size: 14px;
+  font-style: italic;
+  padding: 10px 0;
+}
+
+.medidas-checkbox-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 8px;
+  max-height: 260px;
+  overflow-y: auto;
+  padding: 4px;
+}
+
+.medida-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background-color: white;
+  border: 1px solid #dee2e6;
+  border-radius: 5px;
+  padding: 8px 10px;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.medida-checkbox input {
+  flex-shrink: 0;
+  accent-color: #3498db;
+}
+
+.medida-nombre {
+  flex: 1;
+  color: #2c3e50;
+}
+
+.medida-stock-hint {
+  color: #888;
+  font-size: 12px;
+  white-space: nowrap;
 }
 
 .calcular-btn {

--- a/src/views/AnalisisStock.vue
+++ b/src/views/AnalisisStock.vue
@@ -143,8 +143,8 @@
                 </template>
                 <template v-else>
                   <th class="num">Consumo diario</th>
-                  <th class="num">Días cobertura</th>
-                  <th class="num">Déficit (meta {{ resultado.metaDiasCobertura }}d)</th>
+                  <th class="num">Te dura el stock</th>
+                  <th class="num">Te falta para {{ resultado.metaDiasCobertura }}d</th>
                 </template>
                 <th class="num compra-col">Compra recomendada</th>
                 <th class="num">Stock actual</th>
@@ -227,7 +227,7 @@ export default {
       proveedorSeleccionado: '',
       diasHistorial: 30,
       modo: 'demanda', // 'demanda' | 'cobertura'
-      metaDiasCobertura: 30,
+      metaDiasCobertura: 12,
       proveedores: [],
       proveedoresObjetos: [],
       medidasDisponibles: [],

--- a/src/views/AnalisisStock.vue
+++ b/src/views/AnalisisStock.vue
@@ -165,7 +165,21 @@
                     {{ fila.deficit > 0 ? formatNumber(fila.deficit) + ' kg' : '—' }}
                   </td>
                 </template>
-                <td class="num compra-col"><strong>{{ formatNumber(fila.compra) }} kg</strong></td>
+                <td class="num compra-col">
+                  <div class="compra-editable">
+                    <input
+                      type="number"
+                      class="compra-input"
+                      :class="{ 'compra-editada': fila.compraManual !== null }"
+                      :value="fila.compra"
+                      min="0"
+                      step="1"
+                      :title="fila.compraManual !== null ? 'Cantidad editada manualmente' : 'Compra recomendada (editable)'"
+                      @input="onCompraEditada(fila, $event.target.value)"
+                    />
+                    <span class="compra-unidad">kg</span>
+                  </div>
+                </td>
                 <td class="num" :class="{ 'stock-negativo': fila.stockActual < 0 }">
                   {{ formatNumber(fila.stockActual) }} kg
                 </td>
@@ -190,6 +204,11 @@
               </tr>
             </tfoot>
           </table>
+          <p class="compra-nota">
+            ✏️ Puedes editar la compra de una medida (por ejemplo, si solo hay cierta cantidad
+            disponible en el mercado); el resto se reparte entre las demás medidas. Borra el
+            valor para volver a la recomendación automática.
+          </p>
         </div>
 
         <div v-if="resultado.sinVentas.length > 0" class="sin-ventas-card">
@@ -238,7 +257,11 @@ export default {
       resultado: null,
       // Snapshot de la última consulta a Firestore, para poder recalcular al
       // instante al cambiar de modo o de meta de cobertura sin releer datos.
-      datosCalculo: null
+      datosCalculo: null,
+      // Compras editadas a mano por el usuario (medida -> kilos), por si solo
+      // hay cierta cantidad disponible de esa medida. Se conservan aunque se
+      // cambie de modo o de meta, y se limpian solo con un nuevo cálculo.
+      comprasManualPorMedida: {}
     };
   },
   watch: {
@@ -338,6 +361,7 @@ export default {
       this.medidasSeleccionadas = [];
       this.resultado = null;
       this.datosCalculo = null;
+      this.comprasManualPorMedida = {};
       this.error = '';
 
       if (!this.proveedorSeleccionado) return;
@@ -387,7 +411,7 @@ export default {
       const totalBloques = Math.round(totalKilos / bloque);
 
       if (items.length === 0 || totalBloques <= 0) {
-        return items.map(({ idealKg, ...resto }) => ({ ...resto, compra: 0 }));
+        return items.map(item => ({ ...item, compra: 0 }));
       }
 
       const sumaIdeal = items.reduce((sum, item) => sum + item.idealKg, 0);
@@ -395,7 +419,7 @@ export default {
       if (sumaIdeal <= 0) {
         const base = Math.floor(totalBloques / items.length);
         const resto = totalBloques % items.length;
-        return items.map(({ idealKg, ...item }, index) => ({
+        return items.map((item, index) => ({
           ...item,
           compra: (base + (index < resto ? 1 : 0)) * bloque
         }));
@@ -416,7 +440,7 @@ export default {
         ordenResiduo[i % ordenResiduo.length].bloques += 1;
       }
 
-      return conBloques.map(({ bloquesExactos, bloques, idealKg, ...resto }) => ({
+      return conBloques.map(({ bloquesExactos, bloques, ...resto }) => ({
         ...resto,
         compra: bloques * bloque
       }));
@@ -428,6 +452,7 @@ export default {
       this.error = '';
       this.resultado = null;
       this.datosCalculo = null;
+      this.comprasManualPorMedida = {};
 
       try {
         const proveedor = this.proveedorSeleccionado;
@@ -516,7 +541,12 @@ export default {
         .map(fila => ({
           ...fila,
           porcentaje: totalVendido > 0 ? (fila.vendido / totalVendido) * 100 : 0,
-          stockPostCompra: Number((fila.stockActual + fila.compra).toFixed(1))
+          stockPostCompra: Number((fila.stockActual + fila.compra).toFixed(1)),
+          // Compra editada a mano por el usuario para esta medida, si la hay
+          // (persiste aunque se cambie de modo o de meta de cobertura).
+          compraManual: Object.prototype.hasOwnProperty.call(this.comprasManualPorMedida, fila.medida)
+            ? this.comprasManualPorMedida[fila.medida]
+            : null
         }))
         .sort((a, b) => b.vendido - a.vendido);
 
@@ -542,6 +572,58 @@ export default {
         filas,
         sinVentas
       };
+
+      // Si había compras editadas a mano, respetarlas y repartir el resto
+      // entre las medidas que siguen en automático.
+      this.aplicarBloqueosYRedistribuir();
+    },
+
+    // Se ejecuta cada vez que el usuario edita (o borra) la compra de una
+    // medida. Las medidas con un valor manual quedan "bloqueadas" y no se
+    // tocan al editar otra; las demás se reparten proporcionalmente entre sí
+    // con los kilos que sobran después de restar lo bloqueado.
+    onCompraEditada(fila, valorTexto) {
+      if (!this.resultado) return;
+
+      let valor = null;
+      if (valorTexto !== '' && valorTexto !== null && valorTexto !== undefined) {
+        const parsed = Number(valorTexto);
+        valor = Number.isFinite(parsed) ? Math.max(0, Math.round(parsed)) : null;
+      }
+
+      fila.compraManual = valor;
+      if (valor === null) {
+        this.comprasManualPorMedida = { ...this.comprasManualPorMedida };
+        delete this.comprasManualPorMedida[fila.medida];
+      } else {
+        this.comprasManualPorMedida = { ...this.comprasManualPorMedida, [fila.medida]: valor };
+      }
+
+      this.aplicarBloqueosYRedistribuir();
+    },
+
+    aplicarBloqueosYRedistribuir() {
+      if (!this.resultado || !this.datosCalculo) return;
+
+      const filas = this.resultado.filas;
+      const bloqueadas = filas.filter(fila => fila.compraManual !== null);
+      const libres = filas.filter(fila => fila.compraManual === null);
+
+      const totalBloqueado = bloqueadas.reduce((sum, fila) => sum + fila.compraManual, 0);
+      const kilosRestantes = Math.max(0, this.datosCalculo.kilosAComprar - totalBloqueado);
+
+      const repartidas = this.redondearABloques(libres, kilosRestantes, 500);
+
+      const compraPorMedida = {};
+      bloqueadas.forEach(fila => { compraPorMedida[fila.medida] = fila.compraManual; });
+      repartidas.forEach(fila => { compraPorMedida[fila.medida] = fila.compra; });
+
+      filas.forEach(fila => {
+        fila.compra = compraPorMedida[fila.medida];
+        fila.stockPostCompra = Number((fila.stockActual + fila.compra).toFixed(1));
+      });
+
+      this.resultado.totalCompra = filas.reduce((sum, fila) => sum + fila.compra, 0);
     }
   },
   async created() {
@@ -879,6 +961,48 @@ h2 {
 .resultado-tabla th.compra-col {
   background-color: #3498db;
   color: white;
+}
+
+.compra-editable {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
+}
+
+.compra-input {
+  width: 90px;
+  text-align: right;
+  padding: 6px 8px;
+  border: 1px solid #3498db;
+  border-radius: 4px;
+  font-size: 15px;
+  font-weight: bold;
+  color: #2c3e50;
+  background-color: white;
+}
+
+.compra-input:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(52, 152, 219, 0.35);
+}
+
+.compra-input.compra-editada {
+  border-color: #e67e22;
+  background-color: #fff8ee;
+  color: #e67e22;
+}
+
+.compra-unidad {
+  color: #666;
+  font-size: 13px;
+}
+
+.compra-nota {
+  margin-top: 12px;
+  color: #666;
+  font-size: 13px;
+  font-style: italic;
 }
 
 .resultado-tabla tfoot td {

--- a/src/views/AnalisisStock.vue
+++ b/src/views/AnalisisStock.vue
@@ -149,6 +149,7 @@
                 <th class="num compra-col">Compra recomendada</th>
                 <th class="num">Stock actual</th>
                 <th class="num">Stock post-compra</th>
+                <th v-if="resultado.modo === 'cobertura'" class="num">Cobertura resultante</th>
               </tr>
             </thead>
             <tbody>
@@ -184,6 +185,9 @@
                   {{ formatNumber(fila.stockActual) }} kg
                 </td>
                 <td class="num"><strong>{{ formatNumber(fila.stockPostCompra) }} kg</strong></td>
+                <td v-if="resultado.modo === 'cobertura'" class="num">
+                  {{ fila.coberturaResultante.toFixed(1) }} d
+                </td>
               </tr>
             </tbody>
             <tfoot>
@@ -196,11 +200,14 @@
                 <template v-else>
                   <td class="num"></td>
                   <td class="num"></td>
-                  <td class="num"></td>
+                  <td class="num" :class="{ 'deficit-urgente': resultado.totalDeficit > 0 }">
+                    <strong>{{ formatNumber(resultado.totalDeficit) }} kg</strong>
+                  </td>
                 </template>
                 <td class="num compra-col"><strong>{{ formatNumber(resultado.totalCompra) }} kg</strong></td>
                 <td class="num"><strong>{{ formatNumber(resultado.totalStockActual) }} kg</strong></td>
                 <td class="num"><strong>{{ formatNumber(resultado.totalStockActual + resultado.totalCompra) }} kg</strong></td>
+                <td v-if="resultado.modo === 'cobertura'" class="num"></td>
               </tr>
             </tfoot>
           </table>
@@ -209,6 +216,15 @@
             disponible en el mercado); el resto se reparte entre las demás medidas. Borra el
             valor para volver a la recomendación automática.
           </p>
+
+          <div v-if="resultado.modo === 'cobertura'" class="explicaciones-cobertura">
+            <h4>¿Por qué esta cantidad?</h4>
+            <ul>
+              <li v-for="fila in resultado.filas" :key="'exp-' + fila.medida">
+                {{ explicacionFila(fila) }}
+              </li>
+            </ul>
+          </div>
         </div>
 
         <div v-if="resultado.sinVentas.length > 0" class="sin-ventas-card">
@@ -510,11 +526,10 @@ export default {
         });
 
       const totalVendido = filasBase.reduce((sum, fila) => sum + fila.vendido, 0);
+      const totalDeficit = Number(filasBase.reduce((sum, fila) => sum + fila.deficit, 0).toFixed(1));
 
       let itemsConIdeal;
       if (this.modo === 'cobertura') {
-        const totalDeficit = filasBase.reduce((sum, fila) => sum + fila.deficit, 0);
-
         if (totalDeficit > 0 && totalDeficit > kilosAComprar) {
           // Los déficits superan lo disponible: repartir proporcional al
           // tamaño del déficit para priorizar las medidas más urgentes.
@@ -538,16 +553,21 @@ export default {
       }
 
       const filas = this.redondearABloques(itemsConIdeal, kilosAComprar, 500)
-        .map(fila => ({
-          ...fila,
-          porcentaje: totalVendido > 0 ? (fila.vendido / totalVendido) * 100 : 0,
-          stockPostCompra: Number((fila.stockActual + fila.compra).toFixed(1)),
-          // Compra editada a mano por el usuario para esta medida, si la hay
-          // (persiste aunque se cambie de modo o de meta de cobertura).
-          compraManual: Object.prototype.hasOwnProperty.call(this.comprasManualPorMedida, fila.medida)
-            ? this.comprasManualPorMedida[fila.medida]
-            : null
-        }))
+        .map(fila => {
+          const stockPostCompra = Number((fila.stockActual + fila.compra).toFixed(1));
+          return {
+            ...fila,
+            porcentaje: totalVendido > 0 ? (fila.vendido / totalVendido) * 100 : 0,
+            stockPostCompra,
+            // Para cuántos días te alcanzaría el stock después de esta compra
+            coberturaResultante: Number((stockPostCompra / fila.consumoDiario).toFixed(1)),
+            // Compra editada a mano por el usuario para esta medida, si la hay
+            // (persiste aunque se cambie de modo o de meta de cobertura).
+            compraManual: Object.prototype.hasOwnProperty.call(this.comprasManualPorMedida, fila.medida)
+              ? this.comprasManualPorMedida[fila.medida]
+              : null
+          };
+        })
         .sort((a, b) => b.vendido - a.vendido);
 
       // Medidas seleccionadas sin demanda en el periodo: no reciben compra,
@@ -565,6 +585,7 @@ export default {
         modo: this.modo,
         metaDiasCobertura: metaDias,
         totalVendido: Number(totalVendido.toFixed(1)),
+        totalDeficit,
         totalCompra: filas.reduce((sum, fila) => sum + fila.compra, 0),
         totalStockActual: Number(
           filas.reduce((sum, fila) => sum + fila.stockActual, 0).toFixed(1)
@@ -621,9 +642,38 @@ export default {
       filas.forEach(fila => {
         fila.compra = compraPorMedida[fila.medida];
         fila.stockPostCompra = Number((fila.stockActual + fila.compra).toFixed(1));
+        if (fila.consumoDiario) {
+          fila.coberturaResultante = Number((fila.stockPostCompra / fila.consumoDiario).toFixed(1));
+        }
       });
 
       this.resultado.totalCompra = filas.reduce((sum, fila) => sum + fila.compra, 0);
+    },
+
+    // Texto breve explicando, para una medida, por qué se le asignó (o le
+    // falta) esta cantidad en modo "por días de cobertura".
+    explicacionFila(fila) {
+      const meta = this.resultado.metaDiasCobertura;
+      const dura = fila.diasCobertura.toFixed(1);
+      const resultante = fila.coberturaResultante.toFixed(1);
+
+      if (fila.compraManual !== null) {
+        return `${fila.medida}: cantidad editada a mano (${this.formatNumber(fila.compra)} kg), por ejemplo por disponibilidad ` +
+          `en el mercado. Te duraba ${dura}d antes de comprar; con esto te quedarían ${resultante}d de cobertura.`;
+      }
+
+      if (fila.deficit > 0 && fila.compra < fila.deficit) {
+        return `${fila.medida}: te dura ${dura}d y necesitarías ${this.formatNumber(fila.deficit)} kg para llegar a ${meta}d, ` +
+          `pero no alcanzó el presupuesto; con lo asignado (${this.formatNumber(fila.compra)} kg) te quedarían ${resultante}d de cobertura.`;
+      }
+
+      if (fila.deficit > 0) {
+        return `${fila.medida}: te dura solo ${dura}d, así que primero se cubrió su déficit de ${this.formatNumber(fila.deficit)} kg ` +
+          `para llegar a tu meta de ${meta}d; el resto de tu compra se sumó según su consumo mensual, dejándote ${resultante}d de cobertura.`;
+      }
+
+      return `${fila.medida}: ya te duraba ${dura}d (más que tu meta de ${meta}d), así que no tenía déficit; ` +
+        `esta cantidad es su parte del sobrante repartida según su consumo mensual, dejándote ${resultante}d de cobertura.`;
     }
   },
   async created() {
@@ -1003,6 +1053,32 @@ h2 {
   color: #666;
   font-size: 13px;
   font-style: italic;
+}
+
+.explicaciones-cobertura {
+  margin-top: 15px;
+  padding: 12px 15px;
+  background-color: #f0f7ff;
+  border: 1px solid #bcd9f5;
+  border-radius: 8px;
+}
+
+.explicaciones-cobertura h4 {
+  color: #2c3e50;
+  margin: 0 0 8px 0;
+  font-size: 14px;
+}
+
+.explicaciones-cobertura ul {
+  margin: 0;
+  padding-left: 20px;
+}
+
+.explicaciones-cobertura li {
+  color: #444;
+  font-size: 13px;
+  margin-bottom: 6px;
+  line-height: 1.4;
 }
 
 .resultado-tabla tfoot td {

--- a/src/views/AnalisisStock.vue
+++ b/src/views/AnalisisStock.vue
@@ -54,6 +54,36 @@
           </button>
         </div>
 
+        <div class="modo-selector">
+          <span class="modo-selector-label">Modo de cálculo</span>
+          <div class="modo-opciones">
+            <label class="modo-opcion" :class="{ active: modo === 'demanda' }">
+              <input type="radio" value="demanda" v-model="modo" />
+              <span>
+                <strong>Por demanda (simple)</strong>
+                <small>Proporcional al % de ventas de cada medida</small>
+              </span>
+            </label>
+            <label class="modo-opcion" :class="{ active: modo === 'cobertura' }">
+              <input type="radio" value="cobertura" v-model="modo" />
+              <span>
+                <strong>Por días de cobertura (recomendado)</strong>
+                <small>Prioriza medidas con menos días de stock según su consumo diario</small>
+              </span>
+            </label>
+          </div>
+          <label v-if="modo === 'cobertura'" class="meta-dias-label">
+            Meta de días de cobertura
+            <input
+              v-model.number="metaDiasCobertura"
+              type="number"
+              inputmode="decimal"
+              min="1"
+              step="1"
+            />
+          </label>
+        </div>
+
         <div class="medidas-selector">
           <div class="medidas-selector-header">
             <span>Medidas a incluir{{ proveedorSeleccionado ? ` — ${proveedorSeleccionado}` : '' }}</span>
@@ -92,6 +122,9 @@
           Basado en <strong>{{ formatNumber(resultado.totalVendido) }} kg</strong> de salidas
           entre el {{ resultado.fechaInicio }} y el {{ resultado.fechaFin }}
           ({{ resultado.diasHistorial }} días).
+          <template v-if="resultado.modo === 'cobertura'">
+            Meta de cobertura: <strong>{{ resultado.metaDiasCobertura }} días</strong>.
+          </template>
         </p>
 
         <div v-if="resultado.filas.length === 0" class="sin-datos">
@@ -105,7 +138,14 @@
               <tr>
                 <th>Medida</th>
                 <th class="num">Vendido ({{ resultado.diasHistorial }}d)</th>
-                <th class="num">% Demanda</th>
+                <template v-if="resultado.modo === 'demanda'">
+                  <th class="num">% Demanda</th>
+                </template>
+                <template v-else>
+                  <th class="num">Consumo diario</th>
+                  <th class="num">Días cobertura</th>
+                  <th class="num">Déficit (meta {{ resultado.metaDiasCobertura }}d)</th>
+                </template>
                 <th class="num compra-col">Compra recomendada</th>
                 <th class="num">Stock actual</th>
                 <th class="num">Stock post-compra</th>
@@ -115,7 +155,16 @@
               <tr v-for="fila in resultado.filas" :key="fila.medida">
                 <td>{{ fila.medida }}</td>
                 <td class="num">{{ formatNumber(fila.vendido) }} kg</td>
-                <td class="num">{{ fila.porcentaje.toFixed(1) }}%</td>
+                <template v-if="resultado.modo === 'demanda'">
+                  <td class="num">{{ fila.porcentaje.toFixed(1) }}%</td>
+                </template>
+                <template v-else>
+                  <td class="num">{{ formatNumber(fila.consumoDiario) }} kg/d</td>
+                  <td class="num">{{ fila.diasCobertura.toFixed(1) }} d</td>
+                  <td class="num" :class="{ 'deficit-urgente': fila.deficit > 0 }">
+                    {{ fila.deficit > 0 ? formatNumber(fila.deficit) + ' kg' : '—' }}
+                  </td>
+                </template>
                 <td class="num compra-col"><strong>{{ formatNumber(fila.compra) }} kg</strong></td>
                 <td class="num" :class="{ 'stock-negativo': fila.stockActual < 0 }">
                   {{ formatNumber(fila.stockActual) }} kg
@@ -127,7 +176,14 @@
               <tr>
                 <td><strong>Total</strong></td>
                 <td class="num"><strong>{{ formatNumber(resultado.totalVendido) }} kg</strong></td>
-                <td class="num"><strong>100%</strong></td>
+                <template v-if="resultado.modo === 'demanda'">
+                  <td class="num"><strong>100%</strong></td>
+                </template>
+                <template v-else>
+                  <td class="num"></td>
+                  <td class="num"></td>
+                  <td class="num"></td>
+                </template>
                 <td class="num compra-col"><strong>{{ formatNumber(resultado.totalCompra) }} kg</strong></td>
                 <td class="num"><strong>{{ formatNumber(resultado.totalStockActual) }} kg</strong></td>
                 <td class="num"><strong>{{ formatNumber(resultado.totalStockActual + resultado.totalCompra) }} kg</strong></td>
@@ -170,6 +226,8 @@ export default {
       kilosDisponibles: null,
       proveedorSeleccionado: '',
       diasHistorial: 30,
+      modo: 'demanda', // 'demanda' | 'cobertura'
+      metaDiasCobertura: 30,
       proveedores: [],
       proveedoresObjetos: [],
       medidasDisponibles: [],
@@ -177,8 +235,21 @@ export default {
       cargandoMedidas: false,
       cargando: false,
       error: '',
-      resultado: null
+      resultado: null,
+      // Snapshot de la última consulta a Firestore, para poder recalcular al
+      // instante al cambiar de modo o de meta de cobertura sin releer datos.
+      datosCalculo: null
     };
+  },
+  watch: {
+    modo() {
+      this.recalcularResultado();
+    },
+    metaDiasCobertura() {
+      if (this.modo === 'cobertura') {
+        this.recalcularResultado();
+      }
+    }
   },
   computed: {
     puedeCalcular() {
@@ -266,6 +337,7 @@ export default {
       this.medidasDisponibles = [];
       this.medidasSeleccionadas = [];
       this.resultado = null;
+      this.datosCalculo = null;
       this.error = '';
 
       if (!this.proveedorSeleccionado) return;
@@ -307,33 +379,34 @@ export default {
       }
     },
 
-    // Reparte totalKilos en bloques de "bloque" kg entre las filas, en
-    // proporción a su demanda, usando el método de restos mayores para que
-    // cada compra sea un múltiplo cerrado y la suma cuadre con totalKilos.
-    distribuirEnMultiplos(filas, totalKilos, bloque = 500) {
+    // Reparte totalKilos en bloques de "bloque" kg entre los items, en
+    // proporción a su "idealKg" (el kilaje ideal ya calculado por el modo
+    // activo), usando el método de restos mayores para que cada compra sea
+    // un múltiplo cerrado y la suma cuadre con totalKilos.
+    redondearABloques(items, totalKilos, bloque = 500) {
       const totalBloques = Math.round(totalKilos / bloque);
 
-      if (filas.length === 0 || totalBloques <= 0) {
-        return filas.map(fila => ({ ...fila, compra: 0 }));
+      if (items.length === 0 || totalBloques <= 0) {
+        return items.map(({ idealKg, ...resto }) => ({ ...resto, compra: 0 }));
       }
 
-      const totalDemanda = filas.reduce((sum, fila) => sum + fila.vendido, 0);
+      const sumaIdeal = items.reduce((sum, item) => sum + item.idealKg, 0);
 
-      if (totalDemanda <= 0) {
-        const base = Math.floor(totalBloques / filas.length);
-        const resto = totalBloques % filas.length;
-        return filas.map((fila, index) => ({
-          ...fila,
+      if (sumaIdeal <= 0) {
+        const base = Math.floor(totalBloques / items.length);
+        const resto = totalBloques % items.length;
+        return items.map(({ idealKg, ...item }, index) => ({
+          ...item,
           compra: (base + (index < resto ? 1 : 0)) * bloque
         }));
       }
 
-      const conBloques = filas.map(fila => {
-        const exacto = (fila.vendido / totalDemanda) * totalBloques;
-        return { ...fila, bloquesExactos: exacto, bloques: Math.floor(exacto) };
+      const conBloques = items.map(item => {
+        const exacto = (item.idealKg / sumaIdeal) * totalBloques;
+        return { ...item, bloquesExactos: exacto, bloques: Math.floor(exacto) };
       });
 
-      const asignados = conBloques.reduce((sum, fila) => sum + fila.bloques, 0);
+      const asignados = conBloques.reduce((sum, item) => sum + item.bloques, 0);
       const restantes = totalBloques - asignados;
 
       const ordenResiduo = [...conBloques].sort(
@@ -343,7 +416,7 @@ export default {
         ordenResiduo[i % ordenResiduo.length].bloques += 1;
       }
 
-      return conBloques.map(({ bloquesExactos, bloques, ...resto }) => ({
+      return conBloques.map(({ bloquesExactos, bloques, idealKg, ...resto }) => ({
         ...resto,
         compra: bloques * bloque
       }));
@@ -354,6 +427,7 @@ export default {
       this.cargando = true;
       this.error = '';
       this.resultado = null;
+      this.datosCalculo = null;
 
       try {
         const proveedor = this.proveedorSeleccionado;
@@ -365,56 +439,109 @@ export default {
           proveedor, fechaInicio, fechaFin
         );
 
-        const seleccionadas = new Set(this.medidasSeleccionadas);
-        const kilosAComprar = Number(this.kilosDisponibles) || 0;
-
-        const filasBase = Object.entries(demandaPorMedida)
-          .filter(([medida]) => seleccionadas.has(medida))
-          .map(([medida, vendido]) => ({ medida, vendido: Number(vendido.toFixed(1)) }));
-
-        const totalVendido = filasBase.reduce((sum, fila) => sum + fila.vendido, 0);
-
-        // Compra recomendada en múltiplos cerrados de 500 kg
-        const filas = this.distribuirEnMultiplos(filasBase, kilosAComprar, 500)
-          .map(fila => {
-            const stockActual = Number((stockPorMedida[fila.medida] || 0).toFixed(1));
-            return {
-              medida: fila.medida,
-              vendido: fila.vendido,
-              porcentaje: totalVendido > 0 ? (fila.vendido / totalVendido) * 100 : 0,
-              compra: fila.compra,
-              stockActual,
-              stockPostCompra: Number((stockActual + fila.compra).toFixed(1))
-            };
-          })
-          .sort((a, b) => b.vendido - a.vendido);
-
-        // Medidas seleccionadas sin demanda en el periodo: no reciben compra,
-        // pero se muestran aparte para que no queden ocultas.
-        const sinVentas = this.medidasSeleccionadas
-          .filter(medida => !demandaPorMedida[medida])
-          .map(medida => ({ medida, stockActual: Number((stockPorMedida[medida] || 0).toFixed(1)) }))
-          .sort((a, b) => b.stockActual - a.stockActual);
-
-        this.resultado = {
+        this.datosCalculo = {
           proveedor,
-          diasHistorial: dias,
-          fechaInicio: fechaInicio.format('DD/MM/YYYY'),
-          fechaFin: fechaFin.format('DD/MM/YYYY'),
-          totalVendido: Number(totalVendido.toFixed(1)),
-          totalCompra: filas.reduce((sum, fila) => sum + fila.compra, 0),
-          totalStockActual: Number(
-            filas.reduce((sum, fila) => sum + fila.stockActual, 0).toFixed(1)
-          ),
-          filas,
-          sinVentas
+          dias,
+          fechaInicioTexto: fechaInicio.format('DD/MM/YYYY'),
+          fechaFinTexto: fechaFin.format('DD/MM/YYYY'),
+          demandaPorMedida,
+          stockPorMedida,
+          medidasSeleccionadas: [...this.medidasSeleccionadas],
+          kilosAComprar: Number(this.kilosDisponibles) || 0
         };
+
+        this.recalcularResultado();
       } catch (error) {
         console.error('Error al calcular la distribución:', error);
         this.error = 'No se pudo calcular la distribución: ' + error.message;
       } finally {
         this.cargando = false;
       }
+    },
+
+    // Recalcula la tabla de resultados a partir de los datos ya consultados
+    // (this.datosCalculo), aplicando el modo de cálculo activo. Se usa tanto
+    // al terminar calcular() como al cambiar de modo o la meta de cobertura,
+    // para que el resultado se actualice al instante sin releer Firestore.
+    recalcularResultado() {
+      if (!this.datosCalculo) return;
+
+      const {
+        proveedor, dias, fechaInicioTexto, fechaFinTexto,
+        demandaPorMedida, stockPorMedida, medidasSeleccionadas, kilosAComprar
+      } = this.datosCalculo;
+
+      const metaDias = Number(this.metaDiasCobertura) || 0;
+
+      const filasBase = medidasSeleccionadas
+        .filter(medida => demandaPorMedida[medida])
+        .map(medida => {
+          const vendido = Number(demandaPorMedida[medida].toFixed(1));
+          const stockActual = Number((stockPorMedida[medida] || 0).toFixed(1));
+          const consumoDiario = Number((vendido / dias).toFixed(2));
+          const diasCobertura = Number((stockActual / consumoDiario).toFixed(1));
+          const deficit = Math.max(0, Number(((metaDias - diasCobertura) * consumoDiario).toFixed(1)));
+          return { medida, vendido, stockActual, consumoDiario, diasCobertura, deficit };
+        });
+
+      const totalVendido = filasBase.reduce((sum, fila) => sum + fila.vendido, 0);
+
+      let itemsConIdeal;
+      if (this.modo === 'cobertura') {
+        const totalDeficit = filasBase.reduce((sum, fila) => sum + fila.deficit, 0);
+
+        if (totalDeficit > 0 && totalDeficit > kilosAComprar) {
+          // Los déficits superan lo disponible: repartir proporcional al
+          // tamaño del déficit para priorizar las medidas más urgentes.
+          itemsConIdeal = filasBase.map(fila => ({ ...fila, idealKg: fila.deficit }));
+        } else {
+          // Alcanza para cubrir todos los déficits; lo que sobra se reparte
+          // proporcionalmente al consumo mensual de cada medida.
+          const kilosRestantes = kilosAComprar - totalDeficit;
+          const totalConsumoMensual = filasBase.reduce((sum, fila) => sum + fila.consumoDiario * 30, 0);
+          itemsConIdeal = filasBase.map(fila => {
+            const consumoMensual = fila.consumoDiario * 30;
+            const shareRemanente = totalConsumoMensual > 0
+              ? kilosRestantes * (consumoMensual / totalConsumoMensual)
+              : 0;
+            return { ...fila, idealKg: fila.deficit + shareRemanente };
+          });
+        }
+      } else {
+        // Modo por demanda: reparto proporcional al % de ventas de cada medida
+        itemsConIdeal = filasBase.map(fila => ({ ...fila, idealKg: fila.vendido }));
+      }
+
+      const filas = this.redondearABloques(itemsConIdeal, kilosAComprar, 500)
+        .map(fila => ({
+          ...fila,
+          porcentaje: totalVendido > 0 ? (fila.vendido / totalVendido) * 100 : 0,
+          stockPostCompra: Number((fila.stockActual + fila.compra).toFixed(1))
+        }))
+        .sort((a, b) => b.vendido - a.vendido);
+
+      // Medidas seleccionadas sin demanda en el periodo: no reciben compra,
+      // pero se muestran aparte para que no queden ocultas.
+      const sinVentas = medidasSeleccionadas
+        .filter(medida => !demandaPorMedida[medida])
+        .map(medida => ({ medida, stockActual: Number((stockPorMedida[medida] || 0).toFixed(1)) }))
+        .sort((a, b) => b.stockActual - a.stockActual);
+
+      this.resultado = {
+        proveedor,
+        diasHistorial: dias,
+        fechaInicio: fechaInicioTexto,
+        fechaFin: fechaFinTexto,
+        modo: this.modo,
+        metaDiasCobertura: metaDias,
+        totalVendido: Number(totalVendido.toFixed(1)),
+        totalCompra: filas.reduce((sum, fila) => sum + fila.compra, 0),
+        totalStockActual: Number(
+          filas.reduce((sum, fila) => sum + fila.stockActual, 0).toFixed(1)
+        ),
+        filas,
+        sinVentas
+      };
     }
   },
   async created() {
@@ -506,6 +633,84 @@ h2 {
   border-radius: 5px;
   font-size: 16px;
   background-color: white;
+}
+
+.modo-selector {
+  margin-top: 18px;
+  padding-top: 15px;
+  border-top: 1px solid #dee2e6;
+}
+
+.modo-selector-label {
+  display: block;
+  font-weight: bold;
+  color: #2c3e50;
+  font-size: 14px;
+  margin-bottom: 10px;
+}
+
+.modo-opciones {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 10px;
+}
+
+.modo-opcion {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  background-color: white;
+  border: 2px solid #dee2e6;
+  border-radius: 6px;
+  padding: 10px 12px;
+  cursor: pointer;
+  transition: border-color 0.2s;
+}
+
+.modo-opcion.active {
+  border-color: #3498db;
+  background-color: rgba(52, 152, 219, 0.06);
+}
+
+.modo-opcion input {
+  margin-top: 3px;
+  accent-color: #3498db;
+}
+
+.modo-opcion strong {
+  display: block;
+  color: #2c3e50;
+  font-size: 14px;
+}
+
+.modo-opcion small {
+  display: block;
+  color: #666;
+  font-size: 12px;
+  margin-top: 2px;
+}
+
+.meta-dias-label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-weight: bold;
+  color: #2c3e50;
+  font-size: 14px;
+  margin-top: 12px;
+  max-width: 220px;
+}
+
+.meta-dias-label input {
+  padding: 10px;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  font-size: 16px;
+}
+
+.deficit-urgente {
+  color: #c0392b;
+  font-weight: bold;
 }
 
 .medidas-selector {

--- a/src/views/AnalisisStock.vue
+++ b/src/views/AnalisisStock.vue
@@ -38,6 +38,8 @@
           <label>
             Días de historial
             <select v-model.number="diasHistorial">
+              <option :value="10">10 días</option>
+              <option :value="15">15 días</option>
               <option :value="30">30 días</option>
               <option :value="60">60 días</option>
               <option :value="90">90 días</option>

--- a/src/views/AnalisisStock.vue
+++ b/src/views/AnalisisStock.vue
@@ -1,0 +1,512 @@
+<template>
+  <div class="analisis-stock-page">
+    <div class="analisis-stock-container">
+      <div class="header">
+        <div class="header-left">
+          <BackButton to="/existencias" />
+          <h1>Análisis de Stock</h1>
+        </div>
+      </div>
+
+      <div class="form-card">
+        <h2>Recomendación de Compra</h2>
+        <p class="form-descripcion">
+          Ingresa cuántos kilos puedes comprar y el proveedor; la distribución por medida se
+          calcula con el historial de salidas de los últimos {{ diasHistorial }} días.
+        </p>
+        <div class="form-grid">
+          <label>
+            Kilos a comprar
+            <input
+              v-model.number="kilosDisponibles"
+              type="number"
+              inputmode="decimal"
+              min="0"
+              step="100"
+              placeholder="Ej: 14,000"
+            />
+          </label>
+          <label>
+            Proveedor
+            <select v-model="proveedorSeleccionado">
+              <option value="">Seleccionar proveedor</option>
+              <option v-for="prov in proveedores" :key="prov" :value="prov">
+                {{ prov }}
+              </option>
+            </select>
+          </label>
+          <label>
+            Días de historial
+            <select v-model.number="diasHistorial">
+              <option :value="30">30 días</option>
+              <option :value="60">60 días</option>
+              <option :value="90">90 días</option>
+            </select>
+          </label>
+          <button
+            class="calcular-btn"
+            :disabled="!puedeCalcular || cargando"
+            @click="calcular"
+          >
+            {{ cargando ? 'Calculando...' : 'Calcular Distribución' }}
+          </button>
+        </div>
+      </div>
+
+      <div v-if="error" class="error-box">{{ error }}</div>
+
+      <div v-if="resultado" class="resultado-card">
+        <h2>Distribución recomendada — {{ resultado.proveedor }}</h2>
+        <p class="resultado-info">
+          Basado en <strong>{{ formatNumber(resultado.totalVendido) }} kg</strong> de salidas
+          entre el {{ resultado.fechaInicio }} y el {{ resultado.fechaFin }}
+          ({{ resultado.diasHistorial }} días).
+        </p>
+
+        <div v-if="resultado.filas.length === 0" class="sin-datos">
+          No se encontraron salidas de {{ resultado.proveedor }} en los últimos
+          {{ resultado.diasHistorial }} días, así que no hay demanda con la cual distribuir.
+        </div>
+
+        <div v-else class="tabla-wrapper">
+          <table class="resultado-tabla">
+            <thead>
+              <tr>
+                <th>Medida</th>
+                <th class="num">Vendido ({{ resultado.diasHistorial }}d)</th>
+                <th class="num">% Demanda</th>
+                <th class="num compra-col">Compra recomendada</th>
+                <th class="num">Stock actual</th>
+                <th class="num">Stock post-compra</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="fila in resultado.filas" :key="fila.medida">
+                <td>{{ fila.medida }}</td>
+                <td class="num">{{ formatNumber(fila.vendido) }} kg</td>
+                <td class="num">{{ fila.porcentaje.toFixed(1) }}%</td>
+                <td class="num compra-col"><strong>{{ formatNumber(fila.compra) }} kg</strong></td>
+                <td class="num" :class="{ 'stock-negativo': fila.stockActual < 0 }">
+                  {{ formatNumber(fila.stockActual) }} kg
+                </td>
+                <td class="num"><strong>{{ formatNumber(fila.stockPostCompra) }} kg</strong></td>
+              </tr>
+            </tbody>
+            <tfoot>
+              <tr>
+                <td><strong>Total</strong></td>
+                <td class="num"><strong>{{ formatNumber(resultado.totalVendido) }} kg</strong></td>
+                <td class="num"><strong>100%</strong></td>
+                <td class="num compra-col"><strong>{{ formatNumber(resultado.totalCompra) }} kg</strong></td>
+                <td class="num"><strong>{{ formatNumber(resultado.totalStockActual) }} kg</strong></td>
+                <td class="num"><strong>{{ formatNumber(resultado.totalStockActual + resultado.totalCompra) }} kg</strong></td>
+              </tr>
+            </tfoot>
+          </table>
+        </div>
+
+        <div v-if="resultado.sinVentas.length > 0" class="sin-ventas-card">
+          <h3>Medidas con stock pero sin ventas recientes</h3>
+          <p class="sin-ventas-info">
+            Estas medidas de {{ resultado.proveedor }} tienen existencias pero no registraron
+            salidas en los últimos {{ resultado.diasHistorial }} días (no se les asignó compra):
+          </p>
+          <ul>
+            <li v-for="item in resultado.sinVentas" :key="item.medida">
+              {{ item.medida }}: <strong>{{ formatNumber(item.stockActual) }} kg</strong>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { db } from '@/firebase';
+import { collection, getDocs } from 'firebase/firestore';
+import moment from 'moment';
+import BackButton from '@/components/BackButton.vue';
+import { formatNumber } from '@/utils/formatters';
+
+export default {
+  name: 'AnalisisStock',
+  components: {
+    BackButton
+  },
+  data() {
+    return {
+      kilosDisponibles: null,
+      proveedorSeleccionado: '',
+      diasHistorial: 30,
+      proveedores: [],
+      cargando: false,
+      error: '',
+      resultado: null
+    };
+  },
+  computed: {
+    puedeCalcular() {
+      return this.proveedorSeleccionado &&
+             this.kilosDisponibles &&
+             this.kilosDisponibles > 0;
+    }
+  },
+  methods: {
+    formatNumber,
+
+    parseFechaSacada(fecha) {
+      if (!fecha) return null;
+      if (fecha instanceof Date) return fecha;
+      if (typeof fecha.toDate === 'function') return fecha.toDate();
+      const d = new Date(fecha);
+      return isNaN(d.getTime()) ? null : d;
+    },
+
+    coincideProveedor(proveedorMovimiento, proveedorBuscado) {
+      return String(proveedorMovimiento || '')
+        .toLowerCase()
+        .includes(String(proveedorBuscado || '').toLowerCase());
+    },
+
+    async loadProveedores() {
+      try {
+        const querySnapshot = await getDocs(collection(db, 'proveedores'));
+        this.proveedores = querySnapshot.docs
+          .map(docItem => docItem.data())
+          .filter(p => p.tipo === 'proveedor' && p.nombre)
+          .map(p => p.nombre)
+          .sort((a, b) => a.localeCompare(b));
+      } catch (error) {
+        console.error('Error al cargar proveedores:', error);
+        this.proveedores = [];
+      }
+    },
+
+    async calcular() {
+      if (!this.puedeCalcular || this.cargando) return;
+      this.cargando = true;
+      this.error = '';
+      this.resultado = null;
+
+      try {
+        const proveedor = this.proveedorSeleccionado;
+        const dias = this.diasHistorial;
+        const fechaInicio = moment().subtract(dias, 'days').startOf('day');
+        const fechaFin = moment().endOf('day');
+
+        // Una sola lectura de la colección: sirve tanto para la demanda del
+        // periodo como para el stock actual (entradas - salidas de todo el
+        // histórico), igual que lo calcula la vista de Existencias.
+        const snapshot = await getDocs(collection(db, 'sacadas'));
+
+        const demandaPorMedida = {};
+        const stockPorMedida = {};
+        let totalVendido = 0;
+
+        snapshot.docs.forEach(docSnap => {
+          const sacada = docSnap.data();
+          const fecha = this.parseFechaSacada(sacada.fecha);
+          if (!fecha) return;
+          const enPeriodo = moment(fecha).isBetween(fechaInicio, fechaFin, undefined, '[]');
+
+          (sacada.entradas || []).forEach(entrada => {
+            if (!this.coincideProveedor(entrada.proveedor, proveedor)) return;
+            const medida = String(entrada.medida || '').trim();
+            if (!medida) return;
+            stockPorMedida[medida] = (stockPorMedida[medida] || 0) + (Number(entrada.kilos) || 0);
+          });
+
+          (sacada.salidas || []).forEach(salida => {
+            if (!this.coincideProveedor(salida.proveedor, proveedor)) return;
+            const medida = String(salida.medida || '').trim();
+            if (!medida) return;
+            const kilos = Number(salida.kilos) || 0;
+
+            stockPorMedida[medida] = (stockPorMedida[medida] || 0) - kilos;
+
+            if (enPeriodo && kilos > 0) {
+              demandaPorMedida[medida] = (demandaPorMedida[medida] || 0) + kilos;
+              totalVendido += kilos;
+            }
+          });
+        });
+
+        const kilosAComprar = Number(this.kilosDisponibles) || 0;
+
+        // Distribuir proporcionalmente y absorber el residuo de redondeo en la
+        // medida de mayor demanda, para que la suma cuadre con lo disponible.
+        const filas = Object.entries(demandaPorMedida)
+          .map(([medida, vendido]) => {
+            const porcentaje = totalVendido > 0 ? (vendido / totalVendido) * 100 : 0;
+            return {
+              medida,
+              vendido: Number(vendido.toFixed(1)),
+              porcentaje,
+              compra: Math.round(kilosAComprar * (porcentaje / 100)),
+              stockActual: Number((stockPorMedida[medida] || 0).toFixed(1))
+            };
+          })
+          .sort((a, b) => b.vendido - a.vendido);
+
+        if (filas.length > 0) {
+          const sumaCompras = filas.reduce((sum, fila) => sum + fila.compra, 0);
+          filas[0].compra += kilosAComprar - sumaCompras;
+        }
+
+        filas.forEach(fila => {
+          fila.stockPostCompra = Number((fila.stockActual + fila.compra).toFixed(1));
+        });
+
+        const sinVentas = Object.entries(stockPorMedida)
+          .filter(([medida, kilos]) => !demandaPorMedida[medida] && kilos > 1)
+          .map(([medida, kilos]) => ({ medida, stockActual: Number(kilos.toFixed(1)) }))
+          .sort((a, b) => b.stockActual - a.stockActual);
+
+        this.resultado = {
+          proveedor,
+          diasHistorial: dias,
+          fechaInicio: fechaInicio.format('DD/MM/YYYY'),
+          fechaFin: fechaFin.format('DD/MM/YYYY'),
+          totalVendido: Number(totalVendido.toFixed(1)),
+          totalCompra: kilosAComprar,
+          totalStockActual: Number(
+            filas.reduce((sum, fila) => sum + fila.stockActual, 0).toFixed(1)
+          ),
+          filas,
+          sinVentas
+        };
+      } catch (error) {
+        console.error('Error al calcular la distribución:', error);
+        this.error = 'No se pudo calcular la distribución: ' + error.message;
+      } finally {
+        this.cargando = false;
+      }
+    }
+  },
+  async created() {
+    await this.loadProveedores();
+  }
+};
+</script>
+
+<style scoped>
+.analisis-stock-page {
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding: 20px;
+}
+
+.analisis-stock-container {
+  max-width: 1100px;
+  width: 100%;
+  background-color: white;
+  border-radius: 10px;
+  padding: 20px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+}
+
+.header-left {
+  display: flex;
+  align-items: center;
+  gap: 15px;
+}
+
+h1 {
+  color: #2c3e50;
+  margin: 0;
+  font-size: 24px;
+}
+
+h2 {
+  color: #2c3e50;
+  margin: 0 0 10px 0;
+  font-size: 20px;
+  border-bottom: 2px solid #3498db;
+  padding-bottom: 8px;
+}
+
+.form-card,
+.resultado-card {
+  background-color: #f8f9fa;
+  border: 1px solid #dee2e6;
+  border-radius: 8px;
+  padding: 20px;
+  margin-bottom: 20px;
+}
+
+.form-descripcion {
+  color: #666;
+  margin: 0 0 15px 0;
+  font-size: 14px;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 15px;
+  align-items: end;
+}
+
+.form-grid label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-weight: bold;
+  color: #2c3e50;
+  font-size: 14px;
+}
+
+.form-grid input,
+.form-grid select {
+  padding: 10px;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  font-size: 16px;
+  background-color: white;
+}
+
+.calcular-btn {
+  background-color: #3498db;
+  color: white;
+  border: none;
+  padding: 12px 20px;
+  border-radius: 5px;
+  cursor: pointer;
+  font-size: 16px;
+  font-weight: bold;
+  transition: background-color 0.3s;
+}
+
+.calcular-btn:hover {
+  background-color: #2980b9;
+}
+
+.calcular-btn:disabled {
+  background-color: #ccc;
+  cursor: not-allowed;
+}
+
+.error-box {
+  background-color: #fff1f0;
+  border: 1px solid #f44336;
+  color: #c62828;
+  border-radius: 8px;
+  padding: 12px 15px;
+  margin-bottom: 20px;
+  font-weight: bold;
+}
+
+.resultado-info {
+  color: #555;
+  margin: 0 0 15px 0;
+  font-size: 14px;
+}
+
+.sin-datos {
+  text-align: center;
+  color: #666;
+  padding: 20px;
+  font-style: italic;
+}
+
+.tabla-wrapper {
+  overflow-x: auto;
+}
+
+.resultado-tabla {
+  width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+  font-size: 15px;
+}
+
+.resultado-tabla th,
+.resultado-tabla td {
+  border: 1px solid #dee2e6;
+  padding: 10px 12px;
+  text-align: left;
+}
+
+.resultado-tabla th {
+  background-color: #2c3e50;
+  color: white;
+}
+
+.resultado-tabla .num {
+  text-align: right;
+}
+
+.resultado-tabla tbody tr:nth-child(even) {
+  background-color: #f8f9fa;
+}
+
+.resultado-tabla .compra-col {
+  background-color: rgba(52, 152, 219, 0.08);
+  color: #2c3e50;
+}
+
+.resultado-tabla th.compra-col {
+  background-color: #3498db;
+  color: white;
+}
+
+.resultado-tabla tfoot td {
+  background-color: #ecf0f1;
+  border-top: 2px solid #2c3e50;
+}
+
+.stock-negativo {
+  color: #c62828;
+  font-weight: bold;
+}
+
+.sin-ventas-card {
+  margin-top: 20px;
+  padding: 15px;
+  background-color: #fff8e6;
+  border: 1px solid #e6a700;
+  border-radius: 8px;
+}
+
+.sin-ventas-card h3 {
+  color: #8a6d00;
+  margin: 0 0 8px 0;
+  font-size: 16px;
+}
+
+.sin-ventas-info {
+  color: #666;
+  font-size: 13px;
+  margin: 0 0 10px 0;
+}
+
+.sin-ventas-card ul {
+  margin: 0;
+  padding-left: 20px;
+  columns: 2;
+}
+
+.sin-ventas-card li {
+  margin-bottom: 4px;
+}
+
+@media (max-width: 768px) {
+  .form-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .sin-ventas-card ul {
+    columns: 1;
+  }
+}
+</style>


### PR DESCRIPTION
## Resumen
Nueva página **Análisis de Stock** (`/analisis-stock`), accesible con un botón desde el Reporte de Existencias de limpios, que recomienda cómo distribuir una compra entre medidas según la demanda reciente.

## Cómo funciona
1. El usuario ingresa cuántos kilos puede comprar (ej. 14,000) y selecciona el proveedor (Ahumada, Selecta, etc., cargados de la colección `proveedores`).
2. La app lee la colección `sacadas` y toma las salidas de los últimos 30 días (configurable a 60/90) cuyo proveedor coincide con el seleccionado.
3. Suma los kilos vendidos por medida para obtener el % de demanda de cada una y distribuye los kilos disponibles proporcionalmente, absorbiendo el residuo de redondeo en la medida de mayor demanda para que la suma cuadre exactamente con lo disponible.

## Qué muestra
- Tabla por medida: kilos vendidos en el periodo, % de demanda, **compra recomendada**, **stock actual** (entradas − salidas de todo el histórico, mismo criterio que la vista de Existencias) y **stock post-compra** (actual + recomendada), con fila de totales.
- Lista aparte de medidas con stock pero sin ventas recientes (no se les asigna compra), útil para detectar inventario estancado.
- El stock actual negativo se resalta en rojo como señal de datos por revisar.

## Detalles de implementación
- Una sola lectura de `sacadas` por cálculo: sirve tanto para la demanda del periodo como para el stock actual.
- El filtro por proveedor usa coincidencia por contención sin distinguir mayúsculas, como pidió el flujo (`salida.proveedor` contiene el proveedor elegido).
- Lógica verificada con datos simulados: distribución 75/25 sobre 14,000 kg → 10,500/3,500 exactos, stock histórico correcto y detección de medidas sin ventas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RqBbgDwpWCXqa1rGtXxwj1

---
_Generated by [Claude Code](https://claude.ai/code/session_01RqBbgDwpWCXqa1rGtXxwj1)_