### PR TITLE
Add support for second surplus (sobrante2) in crude items

### DIFF
--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -263,7 +263,8 @@ export default {
       return crudo.items.reduce((total, item) => {
         let taras = this.extraerNumero(item.taras);
         let sobrante = this.extraerNumero(item.sobrante);
-        return total + taras + sobrante;
+        let sobrante2 = this.extraerNumero(item.sobrante2);
+        return total + taras + sobrante + sobrante2;
       }, 0);
     },
     calcularKilosCrudos(item) {
@@ -297,12 +298,12 @@ export default {
         if (formatoGuion) {
           const cantidadSobrante = parseInt(formatoGuion[1]) || 0;
           let medidaSobrante = parseInt(formatoGuion[2]) || 0;
-          
+
           // Si la medida es 19, sustituirla por 20
           if (medidaSobrante === 19) {
             medidaSobrante = 20;
           }
-          
+
           kilosTotales += cantidadSobrante * medidaSobrante;
         } else {
           // Formato original si no coincide con el patrón
@@ -310,7 +311,25 @@ export default {
           kilosTotales += cantidadSobrante * medidaSobrante;
         }
       }
-      
+
+      // Procesar segundo sobrante
+      if (item.sobrante2) {
+        const formatoGuion2 = /^(\d+)-(\d+)$/.exec(item.sobrante2);
+        if (formatoGuion2) {
+          const cantidadSobrante2 = parseInt(formatoGuion2[1]) || 0;
+          let medidaSobrante2 = parseInt(formatoGuion2[2]) || 0;
+
+          if (medidaSobrante2 === 19) {
+            medidaSobrante2 = 20;
+          }
+
+          kilosTotales += cantidadSobrante2 * medidaSobrante2;
+        } else {
+          const [cantidadSobrante2, medidaSobrante2] = item.sobrante2.split('-').map(Number);
+          kilosTotales += cantidadSobrante2 * medidaSobrante2;
+        }
+      }
+
       return kilosTotales;
     },
     extraerNumero(valor) {

--- a/src/constants.js/embarque.js
+++ b/src/constants.js/embarque.js
@@ -71,6 +71,8 @@ export function crearNuevoCrudoItem() {
     taras: null,
     sobrante: null,
     mostrarSobrante: false,
+    sobrante2: null,
+    mostrarSobrante2: false,
     pedidoReferencia: null,
   };
 }

--- a/src/utils/embarqueContenido.js
+++ b/src/utils/embarqueContenido.js
@@ -113,7 +113,7 @@ export function embarqueTieneContenidoOperativoDoc(data) {
     for (const crudo of crudos) {
       const items = Array.isArray(crudo?.items) ? crudo.items : [];
       for (const item of items) {
-        if (stringHasContent(item?.taras) || stringHasContent(item?.sobrante)) return true;
+        if (stringHasContent(item?.taras) || stringHasContent(item?.sobrante) || stringHasContent(item?.sobrante2)) return true;
         const kilos = toNumber(item?.kilos);
         if (Number.isFinite(kilos) && kilos > 0) return true;
       }
@@ -149,7 +149,7 @@ export function embarqueTieneContenidoOperativoEstado({ cargaCon, productos, cli
     for (const crudo of listaCrudos) {
       const items = Array.isArray(crudo?.items) ? crudo.items : [];
       for (const item of items) {
-        if (stringHasContent(item?.taras) || stringHasContent(item?.sobrante)) return true;
+        if (stringHasContent(item?.taras) || stringHasContent(item?.sobrante) || stringHasContent(item?.sobrante2)) return true;
         const kilos = toNumber(item?.kilos);
         if (Number.isFinite(kilos) && kilos > 0) return true;
       }

--- a/src/utils/pdf/resumenTaras.js
+++ b/src/utils/pdf/resumenTaras.js
@@ -195,6 +195,13 @@ function calcularTarasCrudos(crudos) {
         }
       }
 
+      if (item.sobrante2) {
+        const [cantidadSobrante2] = item.sobrante2.split('-').map(Number);
+        if (!isNaN(cantidadSobrante2)) {
+          taras += cantidadSobrante2;
+        }
+      }
+
       return itemTotal + taras;
     }, 0);
   }, 0);

--- a/src/utils/pdfGenerator.js
+++ b/src/utils/pdfGenerator.js
@@ -615,7 +615,7 @@ function contarTotalProductos(embarque) {
           if (crudo && Array.isArray(crudo.items)) {
             contador += crudo.items.filter(item => {
               // Simplificamos la verificación para el conteo
-              return item && (item.taras || item.sobrante);
+              return item && (item.taras || item.sobrante || item.sobrante2);
             }).length;
           }
         });
@@ -1145,10 +1145,15 @@ function calcularKilosCrudosPorMedida(embarque, medida) {
           const [cantidad, peso] = item.sobrante.split('-').map(Number);
           kilosCrudos += cantidad * peso;
         }
+        // Sumar kilos del segundo sobrante si existe
+        if (item.sobrante2) {
+          const [cantidad, peso] = item.sobrante2.split('-').map(Number);
+          kilosCrudos += cantidad * peso;
+        }
       }
     });
   });
-  
+
   return kilosCrudos;
 }
 
@@ -1897,6 +1902,10 @@ function calcularTarasTotales(item) {
     const [cantidadSobrante] = item.sobrante.split('-').map(Number);
     tarasTotales += cantidadSobrante;
   }
+  if (item.sobrante2) {
+    const [cantidadSobrante2] = item.sobrante2.split('-').map(Number);
+    tarasTotales += cantidadSobrante2;
+  }
   return tarasTotales;
 }
 
@@ -2034,7 +2043,13 @@ function calcularKilosCrudos(item, clienteNombre, multiplicadorLorenaGdeCc = 20)
     const [, kilosSobrante] = item.sobrante.split('-').map(Number);
     kilosTotales += kilosSobrante;
   }
-  
+
+  // Procesar segundo sobrante (se suma directamente el peso especificado)
+  if (item.sobrante2) {
+    const [, kilosSobrante2] = item.sobrante2.split('-').map(Number);
+    kilosTotales += kilosSobrante2;
+  }
+
   // Para Elizabeth, redondeamos a entero (sin decimales)
   if (nombreClienteNormalizado.includes('elizabeth')) {
     return Math.round(kilosTotales).toString();

--- a/src/utils/services/EmbarqueCuentasService.js
+++ b/src/utils/services/EmbarqueCuentasService.js
@@ -422,16 +422,23 @@ const prepararItemsJoselito = (productos, clienteCrudos = {}, preciosVenta = new
           if (item.sobrante && item.mostrarSobrante) {
             kilosSobrante = extraerValorSobrante(item.sobrante);
           }
-          
+
+          // Calcular kilos del segundo sobrante - sumar tal cual
+          let kilosSobrante2 = 0;
+          if (item.sobrante2 && item.mostrarSobrante2) {
+            kilosSobrante2 = extraerValorSobrante(item.sobrante2);
+          }
+
           // Para el caso específico "Med c/c" con taras "10-19" y sobrante "1-10",
           // Forzar el total exacto a 200 kg
-          const esProductoEspecifico = 
-            medida.toLowerCase().includes('med c/c') && 
-            item.taras === '10-19' && 
-            item.sobrante === '1-10';
-          
+          const esProductoEspecifico =
+            medida.toLowerCase().includes('med c/c') &&
+            item.taras === '10-19' &&
+            item.sobrante === '1-10' &&
+            !item.sobrante2;
+
           // Suma para llegar a 200 kg total en costos
-          const kilosTotales = esProductoEspecifico ? 200 : kilosTaras + kilosSobrante;
+          const kilosTotales = esProductoEspecifico ? 200 : kilosTaras + kilosSobrante + kilosSobrante2;
           
           // Obtener precio
           const costo = item.precio || 0;
@@ -598,16 +605,23 @@ const prepararItemsVentaJoselito = (productos, clienteCrudos = {}, preciosVenta 
           if (item.sobrante && item.mostrarSobrante) {
             kilosSobrante = parseInt(item.sobrante.split('-').pop()) || 0;
           }
-          
+
+          // Calcular kilos del segundo sobrante - sumar tal cual
+          let kilosSobrante2 = 0;
+          if (item.sobrante2 && item.mostrarSobrante2) {
+            kilosSobrante2 = parseInt(item.sobrante2.split('-').pop()) || 0;
+          }
+
           // Para el caso específico "Med c/c" con taras "10-19" y sobrante "1-10",
           // Forzar el total exacto a 210 kg
-          const esProductoEspecifico = 
-            medida.toLowerCase().includes('med c/c') && 
-            item.taras === '10-19' && 
-            item.sobrante === '1-10';
-          
+          const esProductoEspecifico =
+            medida.toLowerCase().includes('med c/c') &&
+            item.taras === '10-19' &&
+            item.sobrante === '1-10' &&
+            !item.sobrante2;
+
           // Suma para llegar a 210 kg total en ventas
-          const kilosTotales = esProductoEspecifico ? 210 : kilosTaras + kilosSobrante;
+          const kilosTotales = esProductoEspecifico ? 210 : kilosTaras + kilosSobrante + kilosSobrante2;
           
           // Buscar el precio de venta en el mapa de precios
           const precioVenta = preciosVenta.get(medidaNormalizada) || 
@@ -855,7 +869,7 @@ const prepararDatosCuentaCatarro = async (embarqueData) => {
             let kilosSobrante = 0;
             if (item.sobrante && item.mostrarSobrante) {
               kilosSobrante = extraerValorSobrante(item.sobrante);
-              
+
               // Si hay sobrante, también contar las taras del sobrante
               const formatoSobrante = /^(\d+)-(\d+(?:\.\d+)?)$/.exec(item.sobrante);
               if (formatoSobrante) {
@@ -863,15 +877,29 @@ const prepararDatosCuentaCatarro = async (embarqueData) => {
                 totalTarasCrudo += cantidadSobrante;
               }
             }
-            
+
+            // Calcular kilos del segundo sobrante
+            let kilosSobrante2 = 0;
+            if (item.sobrante2 && item.mostrarSobrante2) {
+              kilosSobrante2 = extraerValorSobrante(item.sobrante2);
+
+              // Si hay segundo sobrante, también contar sus taras
+              const formatoSobrante2 = /^(\d+)-(\d+(?:\.\d+)?)$/.exec(item.sobrante2);
+              if (formatoSobrante2) {
+                const cantidadSobrante2 = parseInt(formatoSobrante2[1]) || 0;
+                totalTarasCrudo += cantidadSobrante2;
+              }
+            }
+
             // Para el caso específico "Med c/c" con taras "10-19" y sobrante "1-10",
             // Forzar el total exacto a 200 kg para costos
-            const esProductoEspecifico = 
-              (item.talla || '').toLowerCase().includes('med c/c') && 
-              item.taras === '10-19' && 
-              item.sobrante === '1-10';
-            
-            const kilosCosto = esProductoEspecifico ? 200 : kilosTaras + kilosSobrante;
+            const esProductoEspecifico =
+              (item.talla || '').toLowerCase().includes('med c/c') &&
+              item.taras === '10-19' &&
+              item.sobrante === '1-10' &&
+              !item.sobrante2;
+
+            const kilosCosto = esProductoEspecifico ? 200 : kilosTaras + kilosSobrante + kilosSobrante2;
             
             const medida = item.talla || 'Crudo';
             const medidaNormalizada = normalizarMedida(medida);
@@ -898,10 +926,16 @@ const prepararDatosCuentaCatarro = async (embarqueData) => {
             if (item.sobrante && item.mostrarSobrante) {
               kilosSobranteVenta = extraerValorSobrante(item.sobrante);
             }
-            
+
+            // Calcular kilos del segundo sobrante para ventas
+            let kilosSobranteVenta2 = 0;
+            if (item.sobrante2 && item.mostrarSobrante2) {
+              kilosSobranteVenta2 = extraerValorSobrante(item.sobrante2);
+            }
+
             // Para el caso específico "Med c/c" con taras "10-19" y sobrante "1-10",
             // Forzar el total exacto a 210 kg para ventas
-            const kilosVenta = esProductoEspecifico ? 210 : kilosTarasVenta + kilosSobranteVenta;
+            const kilosVenta = esProductoEspecifico ? 210 : kilosTarasVenta + kilosSobranteVenta + kilosSobranteVenta2;
             
             // Solo agregar el item si tiene kilos
             if (kilosCosto > 0) {
@@ -1118,10 +1152,36 @@ const prepararDatosCuentaOzuna = async (embarqueData) => {
                 }
               }
             }
-            
+
+            // Procesar segundo sobrante
+            if (item.sobrante2) {
+              // Verificar si el sobrante tiene formato "5-19" o similar
+              const formatoGuion2 = /^(\d+)-(\d+)$/.exec(item.sobrante2);
+              if (formatoGuion2) {
+                const cantidadSobrante2 = parseInt(formatoGuion2[1]) || 0;
+                let medidaSobrante2 = parseInt(formatoGuion2[2]) || 0;
+
+                // Si la medida es 19, sustituirla por 20
+                if (medidaSobrante2 === 19) {
+                  medidaSobrante2 = 20;
+                }
+
+                kilosTotales += cantidadSobrante2 * medidaSobrante2;
+              } else {
+                // Formato original si no coincide con el patrón
+                const partes2 = item.sobrante2.split('-').map(Number);
+                if (partes2.length >= 2) {
+                  let valorSobrante2 = partes2[1] || 0;
+                  // Si el segundo valor es 19, sustituirlo por 20
+                  if (valorSobrante2 === 19) valorSobrante2 = 20;
+                  kilosTotales += (partes2[0] || 0) * valorSobrante2;
+                }
+              }
+            }
+
             const kilos = kilosTotales;
             const medida = item.talla || item.medida || 'Crudo';
-            
+
             // Para crudos de Ozuna, aplicar la misma lógica que productos normales
             // Si no es venta (maquila), usar precio fijo de 20, si es venta buscar precios históricos
             let costo = 20; // Por defecto maquila
@@ -1350,7 +1410,37 @@ const prepararDatosCuentaOtilio = async (embarqueData) => {
                 }
               }
             }
-            
+
+            // Procesar segundo sobrante
+            if (item.sobrante2) {
+              // Verificar si el sobrante tiene formato "5-19" o similar
+              const formatoGuion2 = /^(\d+)-(\d+)$/.exec(item.sobrante2);
+              if (formatoGuion2) {
+                const cantidadSobrante2 = parseInt(formatoGuion2[1]) || 0;
+                let medidaSobrante2 = parseInt(formatoGuion2[2]) || 0;
+
+                // Si la medida es 19, sustituirla por 20
+                if (medidaSobrante2 === 19) {
+                  medidaSobrante2 = 20;
+                }
+
+                kilosTotales += cantidadSobrante2 * medidaSobrante2;
+                // Sumar cantidad de taras del segundo sobrante para flete
+                totalTarasCrudo += cantidadSobrante2;
+              } else {
+                // Formato original si no coincide con el patrón
+                const partes2 = item.sobrante2.split('-').map(Number);
+                if (partes2.length >= 2) {
+                  let valorSobrante2 = partes2[1] || 0;
+                  // Si el segundo valor es 19, sustituirlo por 20
+                  if (valorSobrante2 === 19) valorSobrante2 = 20;
+                  kilosTotales += (partes2[0] || 0) * valorSobrante2;
+                  // Sumar cantidad de taras según la primera parte
+                  totalTarasCrudo += (partes2[0] || 0);
+                }
+              }
+            }
+
             const kilosCosto = kilosTotales;
             const kilosVenta = kilosTotales; // Mismos kilos para venta
             const medida = item.talla || item.medida || 'Crudo';
@@ -1903,7 +1993,12 @@ const prepararDatosCuentaVeronica = async (embarqueData) => {
             kilosSobrante = extraerValorSobrante(item.sobrante);
           }
 
-          const kilosCosto = kilosTaras + kilosSobrante;
+          let kilosSobrante2 = 0;
+          if (item.sobrante2 && item.mostrarSobrante2) {
+            kilosSobrante2 = extraerValorSobrante(item.sobrante2);
+          }
+
+          const kilosCosto = kilosTaras + kilosSobrante + kilosSobrante2;
           if (kilosCosto > 0) {
             const medidaCrudo = item.talla || 'Crudo';
             registrarTotalEmbarcado(medidaCrudo, kilosCosto);
@@ -2107,8 +2202,13 @@ const prepararDatosCuentaVeronica = async (embarqueData) => {
             if (item.sobrante && item.mostrarSobrante) {
               kilosSobrante = extraerValorSobrante(item.sobrante);
             }
-            
-            const kilosCosto = kilosTaras + kilosSobrante;
+
+            let kilosSobrante2 = 0;
+            if (item.sobrante2 && item.mostrarSobrante2) {
+              kilosSobrante2 = extraerValorSobrante(item.sobrante2);
+            }
+
+            const kilosCosto = kilosTaras + kilosSobrante + kilosSobrante2;
             const medida = item.talla || 'Crudo';
             const medidaNormalizada = normalizarMedida(medida);
             
@@ -2138,8 +2238,13 @@ const prepararDatosCuentaVeronica = async (embarqueData) => {
             if (item.sobrante && item.mostrarSobrante) {
               kilosSobranteVenta = extraerValorSobrante(item.sobrante);
             }
-            
-            const kilosVenta = kilosTarasVenta + kilosSobranteVenta;
+
+            let kilosSobranteVenta2 = 0;
+            if (item.sobrante2 && item.mostrarSobrante2) {
+              kilosSobranteVenta2 = extraerValorSobrante(item.sobrante2);
+            }
+
+            const kilosVenta = kilosTarasVenta + kilosSobranteVenta + kilosSobranteVenta2;
             
             // Solo agregar el item si tiene kilos
             if (kilosCosto > 0) {

--- a/src/views/Embarques/ListaEmbarques.vue
+++ b/src/views/Embarques/ListaEmbarques.vue
@@ -764,7 +764,27 @@ export default {
                 kilosItem += (cantidadSobrante || 0) * (medidaSobrante || 0);
               }
             }
-            
+
+            // Procesar segundo sobrante
+            if (item.sobrante2) {
+              const formatoGuion2 = /^(\d+)-(\d+)$/.exec(item.sobrante2);
+              if (formatoGuion2) {
+                const cantidadSobrante2 = parseInt(formatoGuion2[1]) || 0;
+                let medidaSobrante2 = parseInt(formatoGuion2[2]) || 0;
+
+                // Si la medida es 19, sustituirla por 20 para el cálculo de ventas
+                if (medidaSobrante2 === 19) {
+                  medidaSobrante2 = 20;
+                }
+
+                kilosItem += cantidadSobrante2 * medidaSobrante2;
+              } else {
+                // Formato original si no coincide con el patrón
+                const [cantidadSobrante2, medidaSobrante2] = item.sobrante2.split('-').map(Number);
+                kilosItem += (cantidadSobrante2 || 0) * (medidaSobrante2 || 0);
+              }
+            }
+
             totalKilosCrudos += kilosItem;
           });
         });
@@ -804,6 +824,10 @@ export default {
                 if (item.sobrante) {
                   const [cantidadSobrante] = item.sobrante.split('-');
                   totalTaras += parseInt(cantidadSobrante) || 0;
+                }
+                if (item.sobrante2) {
+                  const [cantidadSobrante2] = item.sobrante2.split('-');
+                  totalTaras += parseInt(cantidadSobrante2) || 0;
                 }
               });
             }

--- a/src/views/Embarques/NuevoEmbarque.vue
+++ b/src/views/Embarques/NuevoEmbarque.vue
@@ -570,9 +570,13 @@ export default {
             const [cantidadSobrante] = item.sobrante.split('-');
             tarasItem += parseInt(cantidadSobrante) || 0;
           }
+          if (item.sobrante2) {
+            const [cantidadSobrante2] = item.sobrante2.split('-');
+            tarasItem += parseInt(cantidadSobrante2) || 0;
+          }
           return itemTotal + tarasItem;
         }, 0);
-        
+
         return total + tarasCrudo;
       }, 0);
     },
@@ -608,6 +612,10 @@ export default {
             if (item.sobrante) {
               const [cantidadSobrante] = item.sobrante.split('-');
               tarasItem += parseInt(cantidadSobrante) || 0;
+            }
+            if (item.sobrante2) {
+              const [cantidadSobrante2] = item.sobrante2.split('-');
+              tarasItem += parseInt(cantidadSobrante2) || 0;
             }
             return itemTotal + tarasItem;
           }, 0);

--- a/src/views/Embarques/Rendimientos.vue
+++ b/src/views/Embarques/Rendimientos.vue
@@ -1241,16 +1241,39 @@ export default {
                       kilosItem += (cantidadSobrante || 0) * (pesoSobrante || 0);
                     }
                   }
-                  
+
+                  // Procesar segundo sobrante
+                  if (item.sobrante2) {
+                    const formatoGuion2 = /^(\d+)-(\d+)$/.exec(item.sobrante2);
+                    if (formatoGuion2) {
+                      const cantidadSobrante2 = parseInt(formatoGuion2[1]) || 0;
+                      let pesoSobrante2 = parseInt(formatoGuion2[2]) || 0;
+
+                      // Si el peso es 19, usar el peso configurado para costos
+                      if (pesoSobrante2 === 19) {
+                        pesoSobrante2 = this.pesoTaraCosto;
+                      }
+
+                      tarasItem += cantidadSobrante2;
+                      kilosItem += cantidadSobrante2 * pesoSobrante2;
+                    } else {
+                      // Formato original si no coincide con el patrón
+                      const [cantidadSobrante2, pesoSobrante2] = item.sobrante2.split('-').map(Number);
+                      tarasItem += cantidadSobrante2 || 0;
+                      kilosItem += (cantidadSobrante2 || 0) * (pesoSobrante2 || 0);
+                    }
+                  }
+
                   tarasPorMedida[medida].totalTaras += tarasItem;
                   tarasPorMedida[medida].totalKilos += kilosItem;
-                  
+
                     // Agregar detalles para debugging
                     if (tarasItem > 0) {
                       tarasPorMedida[medida].detalles.push({
                         cliente: cliente.nombre,
                         taras: item.taras,
                         sobrante: item.sobrante,
+                        sobrante2: item.sobrante2,
                         tarasCalculadas: tarasItem,
                         kilosCalculados: kilosItem
                       });
@@ -2178,7 +2201,8 @@ export default {
                         gananciaTotal: 0, // Se recalcula después
                         fuentePrecio: fuentePrecio,
                         taras: item.taras,
-                        sobrante: item.sobrante
+                        sobrante: item.sobrante,
+                        sobrante2: item.sobrante2
                       });
                     }
                   }
@@ -2335,9 +2359,32 @@ export default {
           kilosTotales += detalleCalculo.kilosDeSobrante;
         }
       }
-      
+
+      // Procesar segundo sobrante
+      if (item.sobrante2) {
+        const formatoGuion2 = /^(\d+)-(\d+)$/.exec(item.sobrante2);
+        if (formatoGuion2) {
+          const cantidadSobrante2 = parseInt(formatoGuion2[1]) || 0;
+          let pesoSobrante2 = parseInt(formatoGuion2[2]) || 0;
+
+          // Si el peso es 19, usar el peso configurado para ventas
+          if (pesoSobrante2 === 19) {
+            pesoSobrante2 = this.pesoTaraVenta;
+          }
+
+          detalleCalculo.kilosDeSobrante2 = cantidadSobrante2 * pesoSobrante2;
+          kilosTotales += detalleCalculo.kilosDeSobrante2;
+        } else {
+          // Formato original si no coincide con el patrón
+          const [cantidadSobrante2, pesoSobrante2] = item.sobrante2.split('-').map(Number);
+          detalleCalculo.kilosDeSobrante2 = (cantidadSobrante2 || 0) * (pesoSobrante2 || 0);
+          kilosTotales += detalleCalculo.kilosDeSobrante2;
+        }
+      }
+
+      detalleCalculo.sobrante2 = item.sobrante2;
       detalleCalculo.kilosTotales = kilosTotales;
-      
+
       return kilosTotales;
     },
 

--- a/src/views/Embarques/Rendimientos/composables/useGanancias.js
+++ b/src/views/Embarques/Rendimientos/composables/useGanancias.js
@@ -397,7 +397,8 @@ export function useGanancias() {
                       gananciaTotal: gananciaTotal,
                       fuentePrecio: fuentePrecio,
                       taras: item.taras,
-                      sobrante: item.sobrante
+                      sobrante: item.sobrante,
+                      sobrante2: item.sobrante2
                     });
                   }
                 }

--- a/src/views/Embarques/Rendimientos/utils/calculations.js
+++ b/src/views/Embarques/Rendimientos/utils/calculations.js
@@ -91,7 +91,25 @@ export function calcularKilosCrudosItem(item, pesoTaraVenta = 20) {
       kilosTotales += (cantidadSobrante || 0) * (pesoSobrante || 0);
     }
   }
-  
+
+  // Procesar segundo sobrante
+  if (item.sobrante2) {
+    const formatoGuion2 = /^(\d+)-(\d+)$/.exec(item.sobrante2);
+    if (formatoGuion2) {
+      const cantidadSobrante2 = parseInt(formatoGuion2[1]) || 0;
+      let pesoSobrante2 = parseInt(formatoGuion2[2]) || 0;
+
+      if (pesoSobrante2 === 19) {
+        pesoSobrante2 = pesoTaraVenta;
+      }
+
+      kilosTotales += cantidadSobrante2 * pesoSobrante2;
+    } else {
+      const [cantidadSobrante2, pesoSobrante2] = item.sobrante2.split('-').map(Number);
+      kilosTotales += (cantidadSobrante2 || 0) * (pesoSobrante2 || 0);
+    }
+  }
+
   return kilosTotales;
 }
 

--- a/src/views/Embarques/components/ClienteProductos.vue
+++ b/src/views/Embarques/components/ClienteProductos.vue
@@ -351,7 +351,8 @@ export default {
                 return total + crudo.items.reduce((itemTotal, item) => {
                     let taras = this.extraerNumero(item.taras);
                     let sobrante = this.extraerNumero(item.sobrante);
-                    return itemTotal + taras + sobrante;
+                    let sobrante2 = this.extraerNumero(item.sobrante2);
+                    return itemTotal + taras + sobrante + sobrante2;
                 }, 0);
             }, 0);
         },
@@ -485,6 +486,24 @@ export default {
                     // Formato original si no coincide con el patrón
                     const [cantidadSobrante, medidaSobrante] = item.sobrante.split('-').map(Number);
                     kilosTotales += cantidadSobrante * medidaSobrante;
+                }
+            }
+
+            // Procesar segundo sobrante
+            if (item.sobrante2) {
+                const formatoGuion2 = /^(\d+)-(\d+)$/.exec(item.sobrante2);
+                if (formatoGuion2) {
+                    const cantidadSobrante2 = parseInt(formatoGuion2[1]) || 0;
+                    let medidaSobrante2 = parseInt(formatoGuion2[2]) || 0;
+
+                    if (medidaSobrante2 === 19) {
+                        medidaSobrante2 = 20;
+                    }
+
+                    kilosTotales += cantidadSobrante2 * medidaSobrante2;
+                } else {
+                    const [cantidadSobrante2, medidaSobrante2] = item.sobrante2.split('-').map(Number);
+                    kilosTotales += cantidadSobrante2 * medidaSobrante2;
                 }
             }
 

--- a/src/views/Embarques/components/CrudoItem.vue
+++ b/src/views/Embarques/components/CrudoItem.vue
@@ -53,6 +53,9 @@
                         <input v-if="item.mostrarSobrante" type="text" v-model="item.sobrante"
                             class="form-control taras-input" placeholder="Sbrte" @input="actualizarCrudo"
                             :disabled="embarqueBloqueado">
+                        <input v-if="item.mostrarSobrante2" type="text" v-model="item.sobrante2"
+                            class="form-control taras-input" placeholder="Sbrte 2" @input="actualizarCrudo"
+                            :disabled="embarqueBloqueado">
                     </div>
                     <div class="buttons-wrapper">
                         <button type="button" @click="eliminarCrudoItem(itemIndex)"
@@ -173,7 +176,8 @@ export default {
             return this.crudoData.items.reduce((total, item) => {
                 let taras = this.extraerNumero(item.taras);
                 let sobrante = this.extraerNumero(item.sobrante);
-                return total + taras + sobrante;
+                let sobrante2 = this.extraerNumero(item.sobrante2);
+                return total + taras + sobrante + sobrante2;
             }, 0);
         },
 
@@ -192,7 +196,8 @@ export default {
                 if (!talla) return;
                 const taras = this.extraerNumero(item.taras);
                 const sobrante = this.extraerNumero(item.sobrante);
-                mapa[talla] = (mapa[talla] || 0) + taras + sobrante;
+                const sobrante2 = this.extraerNumero(item.sobrante2);
+                mapa[talla] = (mapa[talla] || 0) + taras + sobrante + sobrante2;
             });
             return mapa;
         }
@@ -235,8 +240,10 @@ export default {
                 barco: '',
                 taras: '',
                 sobrante: '',
+                sobrante2: '',
                 precio: null,
                 mostrarSobrante: false,
+                mostrarSobrante2: false,
                 esVenta: this.isClienteOzuna, // Auto-establecer esVenta a true para Ozuna
                 pedidoReferencia: null
             };
@@ -262,18 +269,25 @@ export default {
         },
 
         toggleSobrante(itemIndex) {
-            // Cambiar el estado de mostrarSobrante directamente
-            if (this.crudoData.items && this.crudoData.items.length > itemIndex) {
-                this.crudoData.items[itemIndex].mostrarSobrante = !this.crudoData.items[itemIndex].mostrarSobrante;
-                
-                // Si se oculta el sobrante, limpiar su valor
-                if (!this.crudoData.items[itemIndex].mostrarSobrante) {
-                    this.crudoData.items[itemIndex].sobrante = '';
-                }
-                
-                // Actualizar el componente padre
-                this.actualizarCrudo();
+            // Permite hasta 2 sobrantes por item, ciclando 0 -> 1 -> 2 -> 0
+            if (!this.crudoData.items || this.crudoData.items.length <= itemIndex) return;
+
+            const item = this.crudoData.items[itemIndex];
+            const nivel = (item.mostrarSobrante ? 1 : 0) + (item.mostrarSobrante2 ? 1 : 0);
+
+            if (nivel === 0) {
+                this.$set(item, 'mostrarSobrante', true);
+            } else if (nivel === 1) {
+                this.$set(item, 'mostrarSobrante2', true);
+            } else {
+                this.$set(item, 'mostrarSobrante', false);
+                this.$set(item, 'mostrarSobrante2', false);
+                item.sobrante = '';
+                item.sobrante2 = '';
             }
+
+            // Actualizar el componente padre
+            this.actualizarCrudo();
         },
 
         asignarPrecioAutomaticoCrudo(itemRef = null) {

--- a/src/views/Embarques/components/CuentaFletes/cuentaFletesUtils.js
+++ b/src/views/Embarques/components/CuentaFletes/cuentaFletesUtils.js
@@ -88,8 +88,12 @@ export function calcularTarasCrudos(crudos = []) {
     return total + crudo.items.reduce((itemTotal, item) => {
       const [cantidad = 0] = (item.taras || '').split('-');
       const [cantidadSobrante = 0] = (item.sobrante || '').split('-');
+      const [cantidadSobrante2 = 0] = (item.sobrante2 || '').split('-');
 
-      return itemTotal + (parseInt(cantidad, 10) || 0) + (parseInt(cantidadSobrante, 10) || 0);
+      return itemTotal
+        + (parseInt(cantidad, 10) || 0)
+        + (parseInt(cantidadSobrante, 10) || 0)
+        + (parseInt(cantidadSobrante2, 10) || 0);
     }, 0);
   }, 0);
 }

--- a/src/views/Embarques/mixins/calculosMixin.js
+++ b/src/views/Embarques/mixins/calculosMixin.js
@@ -113,6 +113,26 @@ export default {
         }
       }
 
+      // Procesar segundo sobrante
+      if (item.sobrante2) {
+        const formatoGuion2 = /^(\d+)-(\d+)$/.exec(item.sobrante2);
+        if (formatoGuion2) {
+          const cantidadSobrante2 = parseInt(formatoGuion2[1]) || 0;
+          let medidaSobrante2 = parseInt(formatoGuion2[2]) || 0;
+
+          if (medidaSobrante2 === 19) {
+            medidaSobrante2 = 20;
+          }
+
+          kilosTotales += cantidadSobrante2 * medidaSobrante2;
+        } else {
+          const [cantidadSobrante2, medidaSobrante2] = item.sobrante2
+            .split("-")
+            .map(Number);
+          kilosTotales += cantidadSobrante2 * medidaSobrante2;
+        }
+      }
+
       return kilosTotales;
     },
 
@@ -126,6 +146,10 @@ export default {
       if (item.sobrante) {
         const [cantidadSobrante] = item.sobrante.split("-").map(Number);
         totalTaras += cantidadSobrante;
+      }
+      if (item.sobrante2) {
+        const [cantidadSobrante2] = item.sobrante2.split("-").map(Number);
+        totalTaras += cantidadSobrante2;
       }
       return totalTaras;
     },

--- a/src/views/Embarques/mixins/embarqueCrudosMixin.js
+++ b/src/views/Embarques/mixins/embarqueCrudosMixin.js
@@ -75,10 +75,17 @@ export const embarqueCrudosMixin = {
         return;
       }
       const item = this.clienteCrudos[clienteId][crudoIndex].items[itemIndex];
-      if (!Object.prototype.hasOwnProperty.call(item, 'mostrarSobrante')) {
+      const nivel = (item.mostrarSobrante ? 1 : 0) + (item.mostrarSobrante2 ? 1 : 0);
+
+      if (nivel === 0) {
         this.$set(item, 'mostrarSobrante', true);
+      } else if (nivel === 1) {
+        this.$set(item, 'mostrarSobrante2', true);
       } else {
-        item.mostrarSobrante = !item.mostrarSobrante;
+        this.$set(item, 'mostrarSobrante', false);
+        this.$set(item, 'mostrarSobrante2', false);
+        item.sobrante = '';
+        item.sobrante2 = '';
       }
       this.guardarCambiosEnTiempoReal();
     },

--- a/src/views/Embarques/mixins/embarquePedidoMixin.js
+++ b/src/views/Embarques/mixins/embarquePedidoMixin.js
@@ -302,7 +302,8 @@ export const embarquePedidoMixin = {
             nuevosCrudosPorCliente[clienteIdStr].push({
               talla: definicion.medida || '',
               medida: definicion.medida || '',
-              barco: '', taras: null, sobrante: null, mostrarSobrante: false, precio: null,
+              barco: '', taras: null, sobrante: null, mostrarSobrante: false,
+              sobrante2: null, mostrarSobrante2: false, precio: null,
               pedidoReferencia: definicion.pedidoReferencia
                 ? { taras: definicion.pedidoReferencia.taras || 0 } : null,
             });

--- a/src/views/Embarques/mixins/pdfGenerationMixin.js
+++ b/src/views/Embarques/mixins/pdfGenerationMixin.js
@@ -179,6 +179,11 @@ export default {
                   tarasArray.push(item.sobrante);
                 }
 
+                // Agregar segundo sobrante si existe
+                if (item.sobrante2) {
+                  tarasArray.push(item.sobrante2);
+                }
+
                 return {
                   clienteId,
                   medida: item.talla,

--- a/src/views/RegistroCrudos.vue
+++ b/src/views/RegistroCrudos.vue
@@ -1157,7 +1157,7 @@ export default {
         if (soloCantidad) return Number(soloCantidad[1]) * 19;
         return 0;
       };
-      return Number((parsear(item.taras) + parsear(item.sobrante)).toFixed(1));
+      return Number((parsear(item.taras) + parsear(item.sobrante) + parsear(item.sobrante2)).toFixed(1));
     },
 
     kilosNetosProducto(producto) {

--- a/src/views/Sacadas.vue
+++ b/src/views/Sacadas.vue
@@ -1874,7 +1874,7 @@ export default {
           items.forEach(item => {
             const nombre = String(item.talla || item.medida || '').trim().toLowerCase();
             if (nombre !== 'cam s/c') return;
-            total += this.kilosDeTaraCrudo(item.taras) + this.kilosDeTaraCrudo(item.sobrante);
+            total += this.kilosDeTaraCrudo(item.taras) + this.kilosDeTaraCrudo(item.sobrante) + this.kilosDeTaraCrudo(item.sobrante2);
           });
         });
       });


### PR DESCRIPTION
## Summary
This PR adds support for a second surplus field (`sobrante2`) across the embarque (shipment) system, allowing items to have up to two surplus entries instead of just one. The feature includes UI controls to toggle between 0, 1, or 2 surplus entries, and updates all calculation logic throughout the application to include the second surplus in weight and tare computations.

## Key Changes

### Core Data Structure
- Added `sobrante2` and `mostrarSobrante2` fields to crude item schema in `constants.js/embarque.js`
- Updated `CrudoItem.vue` to display a second surplus input field when `mostrarSobrante2` is enabled
- Modified `toggleSobrante()` logic to cycle through three states: no surplus → first surplus → both surpluses → reset

### Service Layer (EmbarqueCuentasService.js)
- Updated all account preparation functions to calculate and include `kilosSobrante2`:
  - `prepararItemsJoselito()` (costs and sales)
  - `prepararDatosCuentaCatarro()` (costs and sales)
  - `prepararDatosCuentaOzuna()` (with 19→20 weight substitution)
  - `prepararDatosCuentaOtilio()` (with tare counting for freight)
  - `prepararDatosCuentaVeronica()` (multiple sections)
- Updated special case logic to exclude second surplus from forced weight calculations (e.g., "Med c/c" with taras "10-19")

### UI Components & Views
- **Rendimientos.vue**: Added second surplus processing in cost and sales calculations with weight substitution for value 19
- **ClienteProductos.vue**: Updated kilos calculation to include second surplus
- **NuevoEmbarque.vue**: Added second surplus to tare counting
- **ListaEmbarques.vue**: Added second surplus processing for kilos and tares
- **Sidebar.vue**: Updated crude kilos calculation to include second surplus
- **RegistroCrudos.vue**, **Sacadas.vue**: Updated weight calculations

### Utility Functions
- **pdfGenerator.js**: Updated product counting and kilos calculations to include second surplus
- **calculosMixin.js**: Added second surplus processing with weight substitution logic
- **embarqueCrudosMixin.js**: Updated toggle logic to support three-state cycling
- **cuentaFletesUtils.js**: Added second surplus to tare calculations
- **resumenTaras.js**: Included second surplus in tare summation
- **embarqueContenido.js**: Updated content validation to check for second surplus
- **Rendimientos/utils/calculations.js**: Added second surplus with configurable weight handling
- **pdfGenerationMixin.js**: Added second surplus to tares array for PDF generation

### Code Quality
- Standardized whitespace and formatting across modified sections
- Consistent pattern for parsing second surplus format (`\d+-\d+`)
- Special handling for weight value 19 → 20 substitution in multiple contexts

## Implementation Details
- Second surplus follows the same format as first surplus: `quantity-weight` (e.g., "5-19")
- Weight value 19 is automatically converted to 20 in calculations where applicable
- The toggle mechanism cycles: none → sobrante → sobrante2 → none, clearing values on reset
- All existing special cases (e.g., forced totals for specific product types) remain intact and exclude second surplus from their conditions

https://claude.ai/code/session_01A24HPLU7fb3b3yxghBnMfN