### PR TITLE
Corregir el stock que ve el asesor: separar lotes por proveedor

### DIFF
--- a/src/utils/contextoInventario.js
+++ b/src/utils/contextoInventario.js
@@ -1,17 +1,19 @@
 // Arma el resumen de inventario que se le manda al asesor experto (Cloud
-// Function + Claude). Replica la misma lógica de stock de Existencias.vue /
-// Análisis de Stock: bucketizar por medida+precio+cuarto, restar salidas por
-// FIFO dentro del bucket exacto y descartar los kilos sin lote propio.
+// Function + Claude). Replica EXACTAMENTE la lógica de stock del Reporte de
+// Existencias (Existencias.vue): bucketizar por PROVEEDOR + medida + precio +
+// cuarto, restar salidas por FIFO dentro de ese bucket exacto y descartar los
+// kilos que no encuentran lote propio. El desglose es por medida y proveedor,
+// igual que el reporte.
 import { db } from '@/firebase';
 import { collection, getDocs } from 'firebase/firestore';
 import moment from 'moment';
 
 function parseFechaSacada(fecha) {
-  if (!fecha) return null;
+  if (!fecha) return new Date(0);
   if (fecha instanceof Date) return fecha;
   if (typeof fecha.toDate === 'function') return fecha.toDate();
   const d = new Date(fecha);
-  return isNaN(d.getTime()) ? null : d;
+  return isNaN(d.getTime()) ? new Date(0) : d;
 }
 
 function normalizarCuarto(cuarto) {
@@ -19,11 +21,14 @@ function normalizarCuarto(cuarto) {
   return valor.toLowerCase() === 'sin cuarto designado' ? 's/c' : valor;
 }
 
-function claveBucket(medida, precio, cuarto) {
+// Misma fórmula de clave que Existencias.vue, con el proveedor por delante:
+// cada proveedor tiene sus propios lotes y una salida solo consume los suyos.
+function claveBucket(proveedor, medida, precio, cuarto) {
   const c = normalizarCuarto(cuarto);
-  return precio !== null && precio !== undefined
+  const medidaKey = precio !== null && precio !== undefined
     ? `${medida}_$${precio}__${c}`
     : `${medida}__${c}`;
+  return `${proveedor}||${medidaKey}`;
 }
 
 export async function construirContextoInventario(dias = 30) {
@@ -32,58 +37,62 @@ export async function construirContextoInventario(dias = 30) {
 
   const snapshot = await getDocs(collection(db, 'sacadas'));
 
-  // Ordenar cronológicamente: el FIFO depende de que las entradas queden
-  // registradas antes que las salidas que las consumen.
+  // Ordenar cronológicamente, igual que Existencias.vue (fecha inválida = época).
   const sacadas = snapshot.docs
     .map(docSnap => docSnap.data())
     .map(sacada => ({ sacada, fecha: parseFechaSacada(sacada.fecha) }))
-    .filter(item => item.fecha)
     .sort((a, b) => a.fecha - b.fecha);
 
   const buckets = {};
-  const porMedida = {};
+  const porMedidaProveedor = {};
   let totalVendido = 0;
 
-  const asegurarMedida = (medida) => {
-    if (!porMedida[medida]) {
-      porMedida[medida] = { vendido30d: 0, vendido7d: 0, entradas: [] };
+  const claveMP = (medida, proveedor) => `${medida}||${proveedor}`;
+  const asegurarRegistro = (medida, proveedor) => {
+    const clave = claveMP(medida, proveedor);
+    if (!porMedidaProveedor[clave]) {
+      porMedidaProveedor[clave] = {
+        medida,
+        proveedor,
+        vendido30d: 0,
+        vendido7d: 0,
+        entradas: []
+      };
     }
-    return porMedida[medida];
+    return porMedidaProveedor[clave];
   };
 
   sacadas.forEach(({ sacada, fecha }) => {
     (sacada.entradas || []).forEach(entrada => {
       const medida = String(entrada.medida || '').trim();
+      const proveedor = String(entrada.proveedor || '').trim();
       const kilos = Number(entrada.kilos) || 0;
       if (!medida || kilos <= 0) return;
 
       const precio = entrada.precio !== null && entrada.precio !== undefined
         ? entrada.precio
         : null;
-      const clave = claveBucket(medida, precio, entrada.cuartoFrio);
-      if (!buckets[clave]) buckets[clave] = { medida, lotes: [] };
+      const clave = claveBucket(proveedor, medida, precio, entrada.cuartoFrio);
+      if (!buckets[clave]) buckets[clave] = { medida, proveedor, lotes: [] };
       buckets[clave].lotes.push({ kilos });
 
-      asegurarMedida(medida).entradas.push({
-        fecha,
-        kilos,
-        precio,
-        proveedor: entrada.proveedor || null
-      });
+      asegurarRegistro(medida, proveedor).entradas.push({ fecha, kilos, precio });
     });
 
     (sacada.salidas || []).forEach(salida => {
       const medida = String(salida.medida || '').trim();
+      const proveedor = String(salida.proveedor || '').trim();
       const kilos = Number(salida.kilos) || 0;
       if (!medida || kilos <= 0) return;
 
       const precio = salida.precio !== null && salida.precio !== undefined
         ? salida.precio
         : null;
-      const clave = claveBucket(medida, precio, salida.cuartoFrio);
-      if (!buckets[clave]) buckets[clave] = { medida, lotes: [] };
+      const clave = claveBucket(proveedor, medida, precio, salida.cuartoFrio);
+      if (!buckets[clave]) buckets[clave] = { medida, proveedor, lotes: [] };
 
-      // FIFO clampado a cero por lote (mismo comportamiento que Existencias).
+      // FIFO clampado a cero por lote, dentro del bucket del mismo proveedor
+      // (idéntico a Existencias.vue: los kilos sin lote propio se descartan).
       let restante = kilos;
       for (let i = 0; i < buckets[clave].lotes.length && restante > 0; i += 1) {
         const lote = buckets[clave].lotes[i];
@@ -97,7 +106,7 @@ export async function construirContextoInventario(dias = 30) {
       }
 
       // La demanda cuenta la salida completa: representa lo que sí se vendió.
-      const registro = asegurarMedida(medida);
+      const registro = asegurarRegistro(medida, proveedor);
       if (moment(fecha).isSameOrAfter(inicio)) {
         registro.vendido30d += kilos;
         totalVendido += kilos;
@@ -108,20 +117,21 @@ export async function construirContextoInventario(dias = 30) {
     });
   });
 
-  const stockPorMedida = {};
+  // Stock por medida+proveedor: suma de los lotes con saldo positivo.
+  const stockPorMP = {};
   Object.values(buckets).forEach(bucket => {
     const disponible = bucket.lotes.reduce(
       (sum, lote) => sum + Math.max(0, lote.kilos),
       0
     );
     if (disponible <= 0) return;
-    stockPorMedida[bucket.medida] = (stockPorMedida[bucket.medida] || 0) + disponible;
+    const clave = claveMP(bucket.medida, bucket.proveedor);
+    stockPorMP[clave] = (stockPorMP[clave] || 0) + disponible;
   });
 
-  const medidas = Object.keys(porMedida)
-    .map(nombre => {
-      const registro = porMedida[nombre];
-      const stockKg = Number((stockPorMedida[nombre] || 0).toFixed(1));
+  const medidas = Object.entries(porMedidaProveedor)
+    .map(([clave, registro]) => {
+      const stockKg = Number((stockPorMP[clave] || 0).toFixed(1));
       const vendido30dKg = Number(registro.vendido30d.toFixed(1));
       const consumoDiarioKg = Number((vendido30dKg / dias).toFixed(2));
 
@@ -132,7 +142,8 @@ export async function construirContextoInventario(dias = 30) {
       const ultimaEntrada = registro.entradas[0] || null;
 
       return {
-        medida: nombre,
+        medida: registro.medida,
+        proveedor: registro.proveedor || null,
         stockKg,
         vendido30dKg,
         vendido7dKg: Number(registro.vendido7d.toFixed(1)),
@@ -144,14 +155,13 @@ export async function construirContextoInventario(dias = 30) {
         ultimaEntrada: ultimaEntrada
           ? {
               fecha: moment(ultimaEntrada.fecha).format('YYYY-MM-DD'),
-              kilos: Number(ultimaEntrada.kilos.toFixed(1)),
-              proveedor: ultimaEntrada.proveedor
+              kilos: Number(ultimaEntrada.kilos.toFixed(1))
             }
           : null
       };
     })
     .filter(m => m.stockKg > 0 || m.vendido30dKg > 0)
-    .sort((a, b) => b.vendido30dKg - a.vendido30dKg);
+    .sort((a, b) => b.stockKg - a.stockKg || b.vendido30dKg - a.vendido30dKg);
 
   const proveedoresSnapshot = await getDocs(collection(db, 'proveedores'));
   const proveedores = proveedoresSnapshot.docs
@@ -163,6 +173,7 @@ export async function construirContextoInventario(dias = 30) {
   return {
     fecha: moment().format('YYYY-MM-DD'),
     periodoDias: dias,
+    nota: 'Inventario desglosado por medida y proveedor, con la misma lógica del Reporte de Existencias.',
     totalVendido30dKg: Number(totalVendido.toFixed(1)),
     totalStockKg: Number(medidas.reduce((sum, m) => sum + m.stockKg, 0).toFixed(1)),
     proveedores,


### PR DESCRIPTION
## Summary
- El asesor reportaba existencias que no cuadraban con el Reporte de Existencias (ej. inventaba kilos de "selecta" que no existían). La causa: `contextoInventario.js` bucketizaba los lotes solo por `medida+precio+cuarto`, juntando a **todos los proveedores en una misma bolsa** — una salida de un proveedor podía consumir por FIFO los kilos de otro proveedor con la misma medida, precio y cuarto.
- Ahora la clave del bucket incluye el proveedor (`proveedor+medida+precio+cuarto`), que es **exactamente la lógica de Existencias.vue**, y el resumen que ve el asesor viene desglosado por medida y proveedor, igual que el reporte.
- Este cambio es solo del frontend — **no requiere volver a desplegar la Cloud Function** (el deploy de Heroku lo publica solo).

## Test plan
- [x] Verificado con un caso que reproduce la falla: una salida de Selecta ya no consume los lotes de Ahumada de la misma medida/precio/cuarto; el stock por proveedor queda idéntico al que muestra Existencias.
- [x] El módulo compila sin errores.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RqBbgDwpWCXqa1rGtXxwj1)_