### PR TITLE
Add consumption report by measure with historical analysis

### DIFF
--- a/src/components/Existencias.vue
+++ b/src/components/Existencias.vue
@@ -31,6 +31,9 @@
           </div>
         </div>
         <div class="header-actions">
+          <router-link to="/reporte-consumo" class="consumo-button">
+            <span class="btn-icono" aria-hidden="true">📈</span> Consumo Histórico
+          </router-link>
           <router-link to="/analisis-stock" class="analisis-button">
             <span class="btn-icono" aria-hidden="true">📊</span> Análisis de Stock
           </router-link>
@@ -1945,6 +1948,7 @@ h1 {
 }
 
 /* Botones de acción: neón por color con destello que cruza al pasar el mouse. */
+.consumo-button,
 .analisis-button,
 .asesor-button,
 .print-button {
@@ -1966,6 +1970,7 @@ h1 {
   transition: background-color 0.2s, box-shadow 0.2s;
 }
 
+.consumo-button::after,
 .analisis-button::after,
 .asesor-button::after,
 .print-button::after {
@@ -1980,10 +1985,22 @@ h1 {
   transition: left 0.45s ease;
 }
 
+.consumo-button:hover::after,
 .analisis-button:hover::after,
 .asesor-button:hover::after,
 .print-button:hover::after {
   left: 130%;
+}
+
+.consumo-button {
+  color: var(--verde);
+  border-color: rgba(0, 255, 102, 0.55);
+  text-shadow: 0 0 10px rgba(0, 255, 102, 0.5);
+}
+
+.consumo-button:hover {
+  background: rgba(0, 255, 102, 0.14);
+  box-shadow: 0 0 20px rgba(0, 255, 102, 0.35);
 }
 
 .btn-icono {

--- a/src/router.js
+++ b/src/router.js
@@ -136,6 +136,11 @@ const routes = [
     component: AnalisisStock
   },
   {
+    path: '/reporte-consumo',
+    name: 'ReporteConsumoMedidas',
+    component: () => import('@/views/ReporteConsumoMedidas.vue')
+  },
+  {
     path: '/asesor-experto',
     name: 'AsesorExperto',
     component: AsesorExperto

--- a/src/utils/pdf/reporteConsumo.js
+++ b/src/utils/pdf/reporteConsumo.js
@@ -333,51 +333,6 @@ function totalMaquilaPorAnio(maquilas) {
 
 const porKilosDesc = (a, b) => b.kilos - a.kilos;
 
-// Las medidas "sin clasificar" (no empiezan con número: Mixta, Piojo, etc.)
-// no vienen en reporte.medidas; aquí se agrupan por medida para que el PDF
-// las incluya y los totales cuadren con las compras propias.
-function medidasDesdeSinClasificar(sinClasificar) {
-  const porMedida = {};
-  (sinClasificar || []).forEach(item => {
-    if (!porMedida[item.medida]) {
-      porMedida[item.medida] = {
-        base: item.medida,
-        kilos: 0,
-        entradas: 0,
-        porAnio: {},
-        precioSum: 0,
-        precioKilos: 0,
-        proveedores: []
-      };
-    }
-    const med = porMedida[item.medida];
-    med.kilos += item.kilos;
-    med.entradas += item.entradas;
-    Object.keys(item.porAnio || {}).forEach(anio => {
-      med.porAnio[anio] = (med.porAnio[anio] || 0) + item.porAnio[anio];
-    });
-    med.precioSum += item.precioSum || 0;
-    med.precioKilos += item.precioKilos || 0;
-    med.proveedores.push({
-      nombre: item.proveedor,
-      kilos: item.kilos,
-      entradas: item.entradas,
-      porAnio: item.porAnio || {},
-      precioPromedio: item.precioKilos > 0 ? item.precioSum / item.precioKilos : null,
-      variantes: []
-    });
-  });
-  return Object.values(porMedida).map(med => ({
-    ...med,
-    precioPromedio: med.precioKilos > 0 ? med.precioSum / med.precioKilos : null,
-    proveedores: med.proveedores.sort(porKilosDesc)
-  }));
-}
-
-function combinarMedidas(medidas, sinClasificar) {
-  return [...medidas, ...medidasDesdeSinClasificar(sinClasificar)].sort(porKilosDesc);
-}
-
 function topConOtros(items, limite, mapear) {
   const mapeados = items.map(mapear);
   if (mapeados.length <= limite) return mapeados;
@@ -508,7 +463,7 @@ function segmentosProveedores(proveedores, limite) {
 
 export function generarReporteConsumoResumenPDF(datos) {
   const { reporte, proveedores, maquilas } = datos;
-  const medidas = combinarMedidas(datos.medidas, datos.sinClasificar);
+  const medidas = [...datos.medidas].sort(porKilosDesc);
   const rango = { desde: datos.fechaDesde, hasta: datos.fechaHasta };
   const doc = nuevoDocumento();
   const ctx = { doc, subtitulo: 'Resumen ejecutivo' };
@@ -651,7 +606,7 @@ export function generarReporteConsumoResumenPDF(datos) {
 
 export function generarReporteConsumoDetalladoPDF(datos) {
   const { reporte, proveedores, maquilas, mostrarPrecios } = datos;
-  const medidas = combinarMedidas(datos.medidas, datos.sinClasificar);
+  const medidas = [...datos.medidas].sort(porKilosDesc);
   const rango = { desde: datos.fechaDesde, hasta: datos.fechaHasta };
   const doc = nuevoDocumento();
   const ctx = { doc, subtitulo: 'Versión detallada' };

--- a/src/utils/pdf/reporteConsumo.js
+++ b/src/utils/pdf/reporteConsumo.js
@@ -1,0 +1,1024 @@
+// Generación de PDF del Reporte de Consumo por Medida (jsPDF + autotable).
+// Dos versiones: detallada (todas las secciones con tablas completas) y
+// resumen ejecutivo (1-2 páginas con lo esencial). Las gráficas se dibujan
+// vectorialmente con primitivas de jsPDF para que impriman nítidas.
+import jsPDF from 'jspdf';
+import autoTable from 'jspdf-autotable';
+import { formatNumber } from '@/utils/formatters';
+
+const PAGINA = { ancho: 612, alto: 792, margen: 40 };
+const ALTO_ENCABEZADO = 74;
+const ALTO_ENCABEZADO_CONT = 30;
+
+const COLOR = {
+  azulOscuro: [26, 82, 118],
+  azul: [41, 128, 185],
+  azulSuave: [234, 242, 248],
+  azulBorde: [200, 219, 233],
+  filaProveedor: [242, 247, 251],
+  verde: [39, 174, 96],
+  naranja: [230, 126, 34],
+  naranjaOscuro: [156, 100, 12],
+  naranjaSuave: [254, 245, 231],
+  grisTexto: [93, 109, 126],
+  grisLinea: [230, 238, 245],
+  texto: [44, 62, 80],
+  blanco: [255, 255, 255]
+};
+
+// Paleta para series de gráficas (dona / barras).
+const SERIE = [
+  [41, 128, 185],
+  [39, 174, 96],
+  [230, 126, 34],
+  [142, 68, 173],
+  [192, 57, 43],
+  [22, 160, 133],
+  [243, 156, 18],
+  [52, 73, 94],
+  [211, 84, 0],
+  [127, 140, 141]
+];
+
+const kg = n => `${formatNumber(n, 0)} kg`;
+const pct = (parte, total) => (total > 0 ? `${formatNumber((parte / total) * 100, 1)}%` : '0.0%');
+
+function fechaCorta(iso) {
+  if (!iso) return '';
+  const [a, m, d] = iso.split('-');
+  return `${d}/${m}/${a}`;
+}
+
+function ahoraLegible() {
+  const d = new Date();
+  const dd = String(d.getDate()).padStart(2, '0');
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  const hh = String(d.getHours()).padStart(2, '0');
+  const mi = String(d.getMinutes()).padStart(2, '0');
+  return `${dd}/${mm}/${d.getFullYear()} ${hh}:${mi}`;
+}
+
+function nuevoDocumento() {
+  return new jsPDF({ unit: 'pt', format: 'letter' });
+}
+
+// ---------------------------------------------------------------- encabezados
+
+function dibujarEncabezado(doc, subtitulo, rango) {
+  doc.setFillColor(...COLOR.azulOscuro);
+  doc.rect(0, 0, PAGINA.ancho, ALTO_ENCABEZADO, 'F');
+  doc.setFillColor(...COLOR.azul);
+  doc.rect(0, ALTO_ENCABEZADO, PAGINA.ancho, 3, 'F');
+
+  doc.setTextColor(255, 255, 255);
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(9);
+  doc.text('R E Y   P E Z', PAGINA.margen, 24);
+  doc.setFontSize(18);
+  doc.text('Reporte de Consumo por Medida', PAGINA.margen, 46);
+  doc.setFont('helvetica', 'normal');
+  doc.setFontSize(9);
+  doc.setTextColor(190, 215, 235);
+  doc.text(subtitulo, PAGINA.margen, 62);
+
+  doc.setTextColor(255, 255, 255);
+  doc.setFontSize(9);
+  doc.text(`Del ${fechaCorta(rango.desde)} al ${fechaCorta(rango.hasta)}`, PAGINA.ancho - PAGINA.margen, 40, { align: 'right' });
+  doc.setTextColor(190, 215, 235);
+  doc.setFontSize(8);
+  doc.text(`Generado el ${ahoraLegible()}`, PAGINA.ancho - PAGINA.margen, 54, { align: 'right' });
+
+  return ALTO_ENCABEZADO + 24;
+}
+
+function dibujarEncabezadoContinuacion(doc, subtitulo) {
+  doc.setFillColor(...COLOR.azulOscuro);
+  doc.rect(0, 0, PAGINA.ancho, ALTO_ENCABEZADO_CONT - 8, 'F');
+  doc.setTextColor(255, 255, 255);
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(8);
+  doc.text(`Rey Pez · Reporte de Consumo por Medida — ${subtitulo}`, PAGINA.margen, 14);
+  doc.setFont('helvetica', 'normal');
+}
+
+function encabezadoContinuacionSiHaceFalta(doc, subtitulo) {
+  if (doc.internal.getCurrentPageInfo().pageNumber > 1) {
+    dibujarEncabezadoContinuacion(doc, subtitulo);
+  }
+}
+
+function asegurarEspacio(ctx, y, altoNecesario) {
+  if (y + altoNecesario <= PAGINA.alto - 46) return y;
+  ctx.doc.addPage();
+  dibujarEncabezadoContinuacion(ctx.doc, ctx.subtitulo);
+  return ALTO_ENCABEZADO_CONT + 14;
+}
+
+function dibujarPiesDePagina(doc) {
+  const paginas = doc.internal.getNumberOfPages();
+  for (let i = 1; i <= paginas; i += 1) {
+    doc.setPage(i);
+    doc.setDrawColor(...COLOR.azulBorde);
+    doc.setLineWidth(0.75);
+    doc.line(PAGINA.margen, PAGINA.alto - 32, PAGINA.ancho - PAGINA.margen, PAGINA.alto - 32);
+    doc.setFont('helvetica', 'normal');
+    doc.setFontSize(7.5);
+    doc.setTextColor(...COLOR.grisTexto);
+    doc.text('Rey Pez · Tampico, Tamps.', PAGINA.margen, PAGINA.alto - 20);
+    doc.text(`Página ${i} de ${paginas}`, PAGINA.ancho - PAGINA.margen, PAGINA.alto - 20, { align: 'right' });
+  }
+}
+
+// ------------------------------------------------------------------ secciones
+
+function tituloSeccion(ctx, y, texto, nota, color = COLOR.azulOscuro, colorLinea = COLOR.azul) {
+  // Se pide espacio de sobra para que el título nunca quede huérfano al
+  // final de la página (siempre le sigue al menos un bloque).
+  y = asegurarEspacio(ctx, y, 110);
+  const { doc } = ctx;
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(13);
+  doc.setTextColor(...color);
+  doc.text(texto, PAGINA.margen, y);
+  const anchoTitulo = doc.getTextWidth(texto);
+  if (nota) {
+    doc.setFont('helvetica', 'normal');
+    doc.setFontSize(8);
+    doc.setTextColor(...COLOR.grisTexto);
+    doc.text(nota, PAGINA.margen + anchoTitulo + 8, y);
+  }
+  doc.setDrawColor(...colorLinea);
+  doc.setLineWidth(1.5);
+  doc.line(PAGINA.margen, y + 5, PAGINA.ancho - PAGINA.margen, y + 5);
+  return y + 20;
+}
+
+function dibujarTiles(doc, y, tiles) {
+  const gap = 10;
+  const ancho = (PAGINA.ancho - 2 * PAGINA.margen - gap * (tiles.length - 1)) / tiles.length;
+  const alto = 52;
+  tiles.forEach((tile, i) => {
+    const x = PAGINA.margen + i * (ancho + gap);
+    doc.setFillColor(...(tile.fondo || COLOR.azulSuave));
+    doc.setDrawColor(...(tile.borde || COLOR.azulBorde));
+    doc.setLineWidth(0.75);
+    doc.roundedRect(x, y, ancho, alto, 4, 4, 'FD');
+    doc.setFillColor(...(tile.acento || COLOR.azul));
+    doc.roundedRect(x, y, 3.5, alto, 1.5, 1.5, 'F');
+
+    doc.setFont('helvetica', 'bold');
+    doc.setFontSize(6.7);
+    doc.setTextColor(...COLOR.grisTexto);
+    doc.text(String(tile.etiqueta).toUpperCase(), x + 11, y + 14);
+    doc.setFontSize(14.5);
+    doc.setTextColor(...COLOR.azulOscuro);
+    doc.text(tile.valor, x + 11, y + 32);
+    if (tile.sub) {
+      doc.setFont('helvetica', 'normal');
+      doc.setFontSize(7.5);
+      doc.setTextColor(...COLOR.grisTexto);
+      doc.text(tile.sub, x + 11, y + 44);
+    }
+  });
+  return y + alto + 16;
+}
+
+// ------------------------------------------------------------------- gráficas
+
+function dibujarBarrasHorizontales(doc, x, y, ancho, items, opciones = {}) {
+  const altoBarra = opciones.altoBarra || 11;
+  const gap = opciones.gap || 5.5;
+  const anchoEtiqueta = opciones.anchoEtiqueta || 92;
+  const maximo = Math.max(...items.map(i => i.valor), 1);
+  const anchoUtil = ancho - anchoEtiqueta - 84;
+
+  items.forEach((item, idx) => {
+    const yBarra = y + idx * (altoBarra + gap);
+    doc.setFont('helvetica', item.destacar ? 'bold' : 'normal');
+    doc.setFontSize(8);
+    doc.setTextColor(...COLOR.texto);
+    doc.text(String(item.etiqueta), x + anchoEtiqueta - 6, yBarra + altoBarra - 3, { align: 'right' });
+
+    // Riel de fondo + barra.
+    doc.setFillColor(238, 243, 248);
+    doc.roundedRect(x + anchoEtiqueta, yBarra, anchoUtil, altoBarra, 2, 2, 'F');
+    const w = Math.max((item.valor / maximo) * anchoUtil, 1.5);
+    doc.setFillColor(...(item.color || COLOR.azul));
+    doc.roundedRect(x + anchoEtiqueta, yBarra, w, altoBarra, 2, 2, 'F');
+
+    doc.setFont('helvetica', 'bold');
+    doc.setFontSize(7.5);
+    doc.setTextColor(...COLOR.azulOscuro);
+    const texto = item.textoValor || kg(item.valor);
+    doc.text(texto, x + anchoEtiqueta + anchoUtil + 6, yBarra + altoBarra - 3);
+  });
+  return y + items.length * (altoBarra + gap) + 4;
+}
+
+function dibujarBarrasPorAnio(doc, x, y, ancho, alto, anios, series) {
+  // series: [{nombre, color, porAnio}]
+  const maximo = Math.max(
+    ...anios.map(a => Math.max(...series.map(s => s.porAnio[a] || 0))),
+    1
+  );
+  const baseY = y + alto;
+  const anchoGrupo = ancho / anios.length;
+  const anchoBarra = Math.min(26, (anchoGrupo - 24) / series.length);
+
+  doc.setDrawColor(...COLOR.azulBorde);
+  doc.setLineWidth(0.75);
+  doc.line(x, baseY, x + ancho, baseY);
+
+  anios.forEach((anio, i) => {
+    const centro = x + i * anchoGrupo + anchoGrupo / 2;
+    const inicio = centro - (anchoBarra * series.length + 3 * (series.length - 1)) / 2;
+    series.forEach((serie, j) => {
+      const valor = serie.porAnio[anio] || 0;
+      const h = (valor / maximo) * (alto - 16);
+      const bx = inicio + j * (anchoBarra + 3);
+      if (valor > 0) {
+        doc.setFillColor(...serie.color);
+        doc.roundedRect(bx, baseY - h, anchoBarra, h, 1.5, 1.5, 'F');
+        // Tapa el redondeo inferior para que la barra "nazca" plana del eje.
+        doc.rect(bx, baseY - Math.min(h, 3), anchoBarra, Math.min(h, 3), 'F');
+      }
+      doc.setFont('helvetica', 'bold');
+      doc.setFontSize(6.5);
+      doc.setTextColor(...COLOR.texto);
+      doc.text(formatNumber(valor, 0), bx + anchoBarra / 2, baseY - h - 3.5, { align: 'center' });
+    });
+    doc.setFont('helvetica', 'bold');
+    doc.setFontSize(8.5);
+    doc.setTextColor(...COLOR.grisTexto);
+    doc.text(String(anio), centro, baseY + 12, { align: 'center' });
+  });
+
+  // Leyenda.
+  let lx = x;
+  const ly = baseY + 26;
+  series.forEach(serie => {
+    doc.setFillColor(...serie.color);
+    doc.rect(lx, ly - 6, 7, 7, 'F');
+    doc.setFont('helvetica', 'normal');
+    doc.setFontSize(7.5);
+    doc.setTextColor(...COLOR.texto);
+    doc.text(serie.nombre, lx + 10, ly);
+    lx += 10 + doc.getTextWidth(serie.nombre) + 14;
+  });
+  return ly + 12;
+}
+
+function dibujarDona(doc, cx, cy, rExt, rInt, segmentos, centro) {
+  const total = segmentos.reduce((s, seg) => s + seg.valor, 0);
+  if (total <= 0) return;
+  const paso = (2 * Math.PI) / 240;
+  let angulo = -Math.PI / 2;
+  segmentos.forEach(seg => {
+    const fin = angulo + (seg.valor / total) * 2 * Math.PI;
+    doc.setFillColor(...seg.color);
+    for (let a = angulo; a < fin; a += paso) {
+      const b = Math.min(a + paso * 1.5, fin);
+      doc.triangle(
+        cx, cy,
+        cx + rExt * Math.cos(a), cy + rExt * Math.sin(a),
+        cx + rExt * Math.cos(b), cy + rExt * Math.sin(b),
+        'F'
+      );
+    }
+    angulo = fin;
+  });
+  doc.setFillColor(255, 255, 255);
+  doc.circle(cx, cy, rInt, 'F');
+  if (centro) {
+    doc.setFont('helvetica', 'bold');
+    doc.setFontSize(11);
+    doc.setTextColor(...COLOR.azulOscuro);
+    doc.text(centro.valor, cx, cy - 1, { align: 'center' });
+    doc.setFont('helvetica', 'normal');
+    doc.setFontSize(6.5);
+    doc.setTextColor(...COLOR.grisTexto);
+    doc.text(centro.etiqueta, cx, cy + 8, { align: 'center' });
+  }
+}
+
+function dibujarLeyenda(doc, x, y, items, anchoMax) {
+  items.forEach((item, i) => {
+    const ly = y + i * 15;
+    doc.setFillColor(...item.color);
+    doc.roundedRect(x, ly - 6.5, 7.5, 7.5, 1.5, 1.5, 'F');
+    doc.setFont('helvetica', 'bold');
+    doc.setFontSize(7.8);
+    doc.setTextColor(...COLOR.texto);
+    const etiqueta = doc.splitTextToSize(item.etiqueta, anchoMax - 70)[0];
+    doc.text(etiqueta, x + 12, ly);
+    doc.setFont('helvetica', 'normal');
+    doc.setFontSize(7.3);
+    doc.setTextColor(...COLOR.grisTexto);
+    doc.text(item.detalle, x + anchoMax, ly, { align: 'right' });
+  });
+  return y + items.length * 15;
+}
+
+// ------------------------------------------------------------------ utilidades
+
+function totalMaquilaPorAnio(maquilas) {
+  const porAnio = {};
+  maquilas.forEach(maq => {
+    Object.keys(maq.porAnio || {}).forEach(anio => {
+      porAnio[anio] = (porAnio[anio] || 0) + maq.porAnio[anio];
+    });
+  });
+  return porAnio;
+}
+
+const porKilosDesc = (a, b) => b.kilos - a.kilos;
+
+// Las medidas "sin clasificar" (no empiezan con número: Mixta, Piojo, etc.)
+// no vienen en reporte.medidas; aquí se agrupan por medida para que el PDF
+// las incluya y los totales cuadren con las compras propias.
+function medidasDesdeSinClasificar(sinClasificar) {
+  const porMedida = {};
+  (sinClasificar || []).forEach(item => {
+    if (!porMedida[item.medida]) {
+      porMedida[item.medida] = {
+        base: item.medida,
+        kilos: 0,
+        entradas: 0,
+        porAnio: {},
+        precioSum: 0,
+        precioKilos: 0,
+        proveedores: []
+      };
+    }
+    const med = porMedida[item.medida];
+    med.kilos += item.kilos;
+    med.entradas += item.entradas;
+    Object.keys(item.porAnio || {}).forEach(anio => {
+      med.porAnio[anio] = (med.porAnio[anio] || 0) + item.porAnio[anio];
+    });
+    med.precioSum += item.precioSum || 0;
+    med.precioKilos += item.precioKilos || 0;
+    med.proveedores.push({
+      nombre: item.proveedor,
+      kilos: item.kilos,
+      entradas: item.entradas,
+      porAnio: item.porAnio || {},
+      precioPromedio: item.precioKilos > 0 ? item.precioSum / item.precioKilos : null,
+      variantes: []
+    });
+  });
+  return Object.values(porMedida).map(med => ({
+    ...med,
+    precioPromedio: med.precioKilos > 0 ? med.precioSum / med.precioKilos : null,
+    proveedores: med.proveedores.sort(porKilosDesc)
+  }));
+}
+
+function combinarMedidas(medidas, sinClasificar) {
+  return [...medidas, ...medidasDesdeSinClasificar(sinClasificar)].sort(porKilosDesc);
+}
+
+function topConOtros(items, limite, mapear) {
+  const mapeados = items.map(mapear);
+  if (mapeados.length <= limite) return mapeados;
+  const visibles = mapeados.slice(0, limite - 1);
+  const resto = mapeados.slice(limite - 1);
+  visibles.push({
+    etiqueta: 'Otros',
+    valor: resto.reduce((s, i) => s + i.valor, 0)
+  });
+  return visibles;
+}
+
+function entradasDeProveedorAgrupado(prov) {
+  if (prov.proveedoresIndividuales) {
+    return prov.entradas;
+  }
+  return prov.entradas;
+}
+
+function nombreArchivo(tipo, rango) {
+  return `reporte-consumo-${tipo}-${rango.desde}-a-${rango.hasta}.pdf`;
+}
+
+function opcionesTablaBase(ctx, startY, extras = {}) {
+  return {
+    startY,
+    margin: { left: PAGINA.margen, right: PAGINA.margen, top: ALTO_ENCABEZADO_CONT + 12, bottom: 46 },
+    theme: 'grid',
+    styles: {
+      font: 'helvetica',
+      fontSize: 7.8,
+      cellPadding: { top: 3, right: 5, bottom: 3, left: 5 },
+      textColor: COLOR.texto,
+      lineColor: COLOR.grisLinea,
+      lineWidth: 0.5
+    },
+    headStyles: {
+      fillColor: COLOR.azulOscuro,
+      textColor: 255,
+      fontSize: 7.8,
+      fontStyle: 'bold',
+      lineColor: COLOR.azulOscuro
+    },
+    didDrawPage: () => encabezadoContinuacionSiHaceFalta(ctx.doc, ctx.subtitulo),
+    ...extras
+  };
+}
+
+// Estructura las columnas numéricas (años + entradas + precio + kilos + %).
+function alinearNumericasDerecha(dataCell) {
+  if (dataCell.column.index > 0) {
+    dataCell.cell.styles.halign = 'right';
+  }
+}
+
+// --------------------------------------------------------- contenido: resumen
+// Puntos clave calculados a partir de los datos (para el resumen ejecutivo).
+function calcularPuntosClave(datos, todasMedidas) {
+  const { reporte, proveedores } = datos;
+  const puntos = [];
+  if (todasMedidas.length > 0) {
+    const top = todasMedidas[0];
+    puntos.push(`La medida con mayor consumo es ${top.base}: ${kg(top.kilos)} (${pct(top.kilos, reporte.totalKilos)} de las compras propias).`);
+  }
+  if (proveedores.length > 0) {
+    const top = [...proveedores].sort(porKilosDesc)[0];
+    puntos.push(`El proveedor principal es ${top.nombre}: ${kg(top.kilos)} (${pct(top.kilos, reporte.totalKilos)}) en ${entradasDeProveedorAgrupado(top)} entradas.`);
+  }
+  const anios = reporte.anios;
+  if (anios.length >= 2) {
+    const a1 = anios[anios.length - 2];
+    const a2 = anios[anios.length - 1];
+    const v1 = reporte.porAnio[a1] || 0;
+    const v2 = reporte.porAnio[a2] || 0;
+    if (v1 > 0) {
+      const delta = ((v2 - v1) / v1) * 100;
+      const signo = delta >= 0 ? 'más' : 'menos';
+      puntos.push(`En ${a2} se han comprado ${formatNumber(Math.abs(delta), 1)}% ${signo} kilos que en ${a1} (${kg(v2)} vs ${kg(v1)}).`);
+    }
+  }
+  if (reporte.maquilaKilos > 0) {
+    const totalProcesado = reporte.totalKilos + reporte.maquilaKilos;
+    puntos.push(`La maquila aporta ${kg(reporte.maquilaKilos)} adicionales: el volumen total procesado es ${kg(totalProcesado)}.`);
+  }
+  return puntos;
+}
+
+function tilesPrincipales(reporte) {
+  return [
+    {
+      etiqueta: 'Compras propias',
+      valor: kg(reporte.totalKilos),
+      sub: `${reporte.totalEntradas} entradas`,
+      acento: COLOR.azul
+    },
+    {
+      etiqueta: 'Maquila (Ozuna / Joselito)',
+      valor: kg(reporte.maquilaKilos),
+      sub: `${reporte.maquilaEntradas} entradas`,
+      fondo: COLOR.naranjaSuave,
+      borde: [245, 217, 168],
+      acento: COLOR.naranja
+    },
+    {
+      etiqueta: 'Volumen total procesado',
+      valor: kg(reporte.totalKilos + reporte.maquilaKilos),
+      sub: `${reporte.totalEntradas + reporte.maquilaEntradas} entradas`,
+      fondo: [232, 248, 240],
+      borde: [184, 230, 206],
+      acento: COLOR.verde
+    }
+  ];
+}
+
+function segmentosProveedores(proveedores, limite) {
+  const ordenados = [...proveedores].sort(porKilosDesc);
+  const items = topConOtros(ordenados, limite, p => ({
+    etiqueta: p.nombre,
+    valor: p.kilos
+  }));
+  return items.map((item, i) => ({
+    ...item,
+    color: item.etiqueta === 'Otros' ? [176, 190, 197] : SERIE[i % SERIE.length]
+  }));
+}
+
+// ================================================================== RESUMEN
+
+export function generarReporteConsumoResumenPDF(datos) {
+  const { reporte, proveedores, maquilas } = datos;
+  const medidas = combinarMedidas(datos.medidas, datos.sinClasificar);
+  const rango = { desde: datos.fechaDesde, hasta: datos.fechaHasta };
+  const doc = nuevoDocumento();
+  const ctx = { doc, subtitulo: 'Resumen ejecutivo' };
+
+  let y = dibujarEncabezado(doc, 'Resumen ejecutivo · Entradas de producto', rango);
+
+  // ---- KPIs
+  y = dibujarTiles(doc, y, tilesPrincipales(reporte));
+
+  // ---- Puntos clave
+  const puntos = calcularPuntosClave(datos, medidas);
+  if (puntos.length > 0) {
+    const altoCaja = 16 + puntos.length * 13;
+    doc.setFillColor(247, 250, 253);
+    doc.setDrawColor(...COLOR.azulBorde);
+    doc.setLineWidth(0.75);
+    doc.roundedRect(PAGINA.margen, y, PAGINA.ancho - 2 * PAGINA.margen, altoCaja, 4, 4, 'FD');
+    doc.setFont('helvetica', 'bold');
+    doc.setFontSize(8);
+    doc.setTextColor(...COLOR.azulOscuro);
+    doc.text('PUNTOS CLAVE', PAGINA.margen + 12, y + 13);
+    doc.setFont('helvetica', 'normal');
+    doc.setFontSize(8);
+    doc.setTextColor(...COLOR.texto);
+    puntos.forEach((punto, i) => {
+      doc.setFillColor(...COLOR.azul);
+      doc.circle(PAGINA.margen + 16, y + 23.5 + i * 13, 1.5, 'F');
+      doc.text(punto, PAGINA.margen + 24, y + 26 + i * 13);
+    });
+    y += altoCaja + 18;
+  }
+
+  // ---- Gráficas: barras de medidas (izq) + dona de proveedores (der)
+  y = tituloSeccion(ctx, y, 'Consumo por medida y proveedor', '(compras propias)');
+  if (medidas.length === 0) {
+    doc.setFont('helvetica', 'italic');
+    doc.setFontSize(9);
+    doc.setTextColor(...COLOR.grisTexto);
+    doc.text('Sin entradas en este período.', PAGINA.margen, y + 8);
+    y += 28;
+  } else {
+    const yGraficas = y + 6;
+    const anchoIzq = 300;
+    const barras = topConOtros(medidas, 8, m => ({
+      etiqueta: m.base,
+      valor: m.kilos
+    })).map(item => ({
+      ...item,
+      color: item.etiqueta === 'Otros' ? [176, 190, 197] : COLOR.azul,
+      textoValor: `${formatNumber(item.valor, 0)} · ${pct(item.valor, reporte.totalKilos)}`
+    }));
+    const yFinBarras = dibujarBarrasHorizontales(doc, PAGINA.margen, yGraficas, anchoIzq, barras);
+
+    const segmentos = segmentosProveedores(proveedores, 6);
+    const cx = PAGINA.margen + anchoIzq + 78;
+    const cy = yGraficas + 52;
+    dibujarDona(doc, cx, cy, 50, 30, segmentos, {
+      valor: formatNumber(reporte.totalKilos / 1000, 0) + 'k',
+      etiqueta: 'kg propios'
+    });
+    const yFinLeyenda = dibujarLeyenda(
+      doc,
+      PAGINA.margen + anchoIzq + 24,
+      cy + 66,
+      segmentos.map(s => ({
+        color: s.color,
+        etiqueta: s.etiqueta,
+        detalle: pct(s.valor, reporte.totalKilos)
+      })),
+      PAGINA.ancho - PAGINA.margen - (PAGINA.margen + anchoIzq + 24)
+    );
+
+    y = Math.max(yFinBarras, yFinLeyenda) + 14;
+  }
+
+  // ---- Tabla compacta por medida
+  y = tituloSeccion(ctx, y, 'Kilos por medida y año', '(compras propias)');
+  const filasMedidas = topConOtros(medidas, 12, m => ({
+    etiqueta: m.base,
+    valor: m.kilos,
+    porAnio: m.porAnio,
+    entradas: m.entradas
+  }));
+  autoTable(doc, opcionesTablaBase(ctx, y, {
+    head: [['Medida', ...reporte.anios.map(String), 'Entradas', 'Kilos', '% del total']],
+    body: filasMedidas.map(m => [
+      m.etiqueta,
+      ...reporte.anios.map(a => (m.porAnio && m.porAnio[a] ? formatNumber(m.porAnio[a], 0) : '—')),
+      m.entradas != null ? String(m.entradas) : '—',
+      formatNumber(m.valor, 0),
+      pct(m.valor, reporte.totalKilos)
+    ]),
+    foot: [[
+      'Total compras propias',
+      ...reporte.anios.map(a => formatNumber(reporte.porAnio[a] || 0, 0)),
+      String(reporte.totalEntradas),
+      formatNumber(reporte.totalKilos, 0),
+      reporte.totalKilos > 0 ? '100%' : '—'
+    ]],
+    footStyles: {
+      fillColor: COLOR.azulSuave,
+      textColor: COLOR.azulOscuro,
+      fontStyle: 'bold',
+      fontSize: 7.8,
+      lineColor: COLOR.azulBorde
+    },
+    showFoot: 'lastPage',
+    didParseCell: data => {
+      alinearNumericasDerecha(data);
+    }
+  }));
+  y = doc.lastAutoTable.finalY + 16;
+
+  // ---- Maquila en una línea
+  if (maquilas.length > 0) {
+    y = asegurarEspacio(ctx, y, 46);
+    doc.setFillColor(...COLOR.naranjaSuave);
+    doc.setDrawColor(245, 217, 168);
+    doc.setLineWidth(0.75);
+    doc.roundedRect(PAGINA.margen, y, PAGINA.ancho - 2 * PAGINA.margen, 34, 4, 4, 'FD');
+    doc.setFont('helvetica', 'bold');
+    doc.setFontSize(8);
+    doc.setTextColor(...COLOR.naranjaOscuro);
+    doc.text('MAQUILA (PRODUCTO DE TERCEROS)', PAGINA.margen + 12, y + 13);
+    doc.setFont('helvetica', 'normal');
+    doc.setFontSize(8.5);
+    doc.setTextColor(...COLOR.texto);
+    const detalle = maquilas
+      .map(maq => `${maq.nombre}: ${kg(maq.kilos)} (${maq.entradas} entradas)`)
+      .join('   ·   ');
+    doc.text(detalle, PAGINA.margen + 12, y + 26);
+    y += 34;
+  }
+
+  dibujarPiesDePagina(doc);
+  doc.save(nombreArchivo('resumen', rango));
+}
+
+// ================================================================= DETALLADO
+
+export function generarReporteConsumoDetalladoPDF(datos) {
+  const { reporte, proveedores, maquilas, mostrarPrecios } = datos;
+  const medidas = combinarMedidas(datos.medidas, datos.sinClasificar);
+  const rango = { desde: datos.fechaDesde, hasta: datos.fechaHasta };
+  const doc = nuevoDocumento();
+  const ctx = { doc, subtitulo: 'Versión detallada' };
+
+  let y = dibujarEncabezado(doc, 'Versión detallada · Entradas de producto', rango);
+
+  // ---- KPIs principales + por año
+  y = dibujarTiles(doc, y, tilesPrincipales(reporte));
+  if (reporte.anios.length > 0) {
+    y = dibujarTiles(doc, y - 6, reporte.anios.map(anio => ({
+      etiqueta: `Compras ${anio}`,
+      valor: kg(reporte.porAnio[anio] || 0),
+      acento: COLOR.azul
+    })));
+  }
+
+  // ---- Gráficas
+  y = tituloSeccion(ctx, y, 'Resumen visual', '(compras propias)');
+  if (medidas.length === 0) {
+    doc.setFont('helvetica', 'italic');
+    doc.setFontSize(9);
+    doc.setTextColor(...COLOR.grisTexto);
+    doc.text('Sin entradas en este período.', PAGINA.margen, y + 8);
+    y += 28;
+  } else {
+    const yGraficas = y + 6;
+    const barras = topConOtros(medidas, 10, m => ({
+      etiqueta: m.base,
+      valor: m.kilos
+    })).map(item => ({
+      ...item,
+      color: item.etiqueta === 'Otros' ? [176, 190, 197] : COLOR.azul,
+      textoValor: `${formatNumber(item.valor, 0)} · ${pct(item.valor, reporte.totalKilos)}`
+    }));
+    const yFinBarras = dibujarBarrasHorizontales(doc, PAGINA.margen, yGraficas, 330, barras);
+
+    // Dona de proveedores a la derecha de las barras.
+    const segmentos = segmentosProveedores(proveedores, 6);
+    const cxDona = PAGINA.margen + 330 + 90;
+    const cyDona = yGraficas + 52;
+    dibujarDona(doc, cxDona, cyDona, 52, 31, segmentos, {
+      valor: formatNumber(reporte.totalKilos / 1000, 0) + 'k',
+      etiqueta: 'kg propios'
+    });
+    const yLeyenda = dibujarLeyenda(
+      doc,
+      PAGINA.margen + 330 + 26,
+      cyDona + 68,
+      segmentos.map(s => ({
+        color: s.color,
+        etiqueta: s.etiqueta,
+        detalle: pct(s.valor, reporte.totalKilos)
+      })),
+      PAGINA.ancho - PAGINA.margen - (PAGINA.margen + 330 + 26)
+    );
+    y = Math.max(yFinBarras, yLeyenda) + 14;
+
+    // Barras por año: compras propias vs maquila.
+    y = asegurarEspacio(ctx, y, 150);
+    doc.setFont('helvetica', 'bold');
+    doc.setFontSize(9.5);
+    doc.setTextColor(...COLOR.azulOscuro);
+    doc.text('Kilos por año', PAGINA.margen, y + 4);
+    const seriesAnio = [
+      { nombre: 'Compras propias', color: COLOR.azul, porAnio: reporte.porAnio }
+    ];
+    const maquilaPorAnio = totalMaquilaPorAnio(maquilas);
+    if (Object.keys(maquilaPorAnio).length > 0) {
+      seriesAnio.push({ nombre: 'Maquila', color: COLOR.naranja, porAnio: maquilaPorAnio });
+    }
+    y = dibujarBarrasPorAnio(doc, PAGINA.margen + 10, y + 14, PAGINA.ancho - 2 * PAGINA.margen - 20, 100, reporte.anios, seriesAnio) + 10;
+  }
+
+  // ---- Global por medida
+  y = tituloSeccion(ctx, y, 'Global por medida', '(compras propias, sin maquila)');
+  medidas.forEach(medida => {
+    y = asegurarEspacio(ctx, y, 90);
+
+    // Encabezado de la medida.
+    doc.setFillColor(...COLOR.azulSuave);
+    doc.roundedRect(PAGINA.margen, y, PAGINA.ancho - 2 * PAGINA.margen, 20, 3, 3, 'F');
+    doc.setFillColor(...COLOR.azul);
+    doc.roundedRect(PAGINA.margen, y, 3.5, 20, 1.5, 1.5, 'F');
+    doc.setFont('helvetica', 'bold');
+    doc.setFontSize(10.5);
+    doc.setTextColor(...COLOR.azulOscuro);
+    doc.text(medida.base, PAGINA.margen + 12, y + 14);
+    doc.setFont('helvetica', 'normal');
+    doc.setFontSize(8);
+    doc.setTextColor(...COLOR.grisTexto);
+    const resumenMedida = [
+      kg(medida.kilos),
+      `${pct(medida.kilos, reporte.totalKilos)} del total`,
+      `${medida.entradas} entradas`
+    ];
+    if (mostrarPrecios && medida.precioPromedio) {
+      resumenMedida.push(`prom. $${formatNumber(medida.precioPromedio)}`);
+    }
+    doc.text(resumenMedida.join('  ·  '), PAGINA.ancho - PAGINA.margen - 8, y + 14, { align: 'right' });
+    y += 26;
+
+    // Filas: proveedor (subtotal) + variantes.
+    const cuerpo = [];
+    const tipos = [];
+    medida.proveedores.forEach(prov => {
+      cuerpo.push([
+        prov.nombre,
+        ...reporte.anios.map(a => (prov.porAnio[a] ? formatNumber(prov.porAnio[a], 0) : '—')),
+        String(prov.entradas),
+        ...(mostrarPrecios ? [prov.precioPromedio ? `$${formatNumber(prov.precioPromedio)}` : '—'] : []),
+        formatNumber(prov.kilos, 0)
+      ]);
+      tipos.push('proveedor');
+      if (prov.variantes.length > 1 || (prov.variantes[0] && prov.variantes[0].medida !== medida.base)) {
+        prov.variantes.forEach(variante => {
+          cuerpo.push([
+            `    ${variante.medida}`,
+            ...reporte.anios.map(a => (variante.porAnio[a] ? formatNumber(variante.porAnio[a], 0) : '—')),
+            String(variante.entradas),
+            ...(mostrarPrecios ? [variante.precioPromedio ? `$${formatNumber(variante.precioPromedio)}` : '—'] : []),
+            formatNumber(variante.kilos, 0)
+          ]);
+          tipos.push('variante');
+        });
+      }
+    });
+
+    autoTable(doc, opcionesTablaBase(ctx, y, {
+      head: [[
+        'Proveedor / Medida',
+        ...reporte.anios.map(String),
+        'Entradas',
+        ...(mostrarPrecios ? ['Precio prom.'] : []),
+        'Kilos'
+      ]],
+      body: cuerpo,
+      foot: [[
+        `Total ${medida.base}`,
+        ...reporte.anios.map(a => (medida.porAnio[a] ? formatNumber(medida.porAnio[a], 0) : '—')),
+        String(medida.entradas),
+        ...(mostrarPrecios ? [medida.precioPromedio ? `$${formatNumber(medida.precioPromedio)}` : '—'] : []),
+        formatNumber(medida.kilos, 0)
+      ]],
+      footStyles: {
+        fillColor: COLOR.azulSuave,
+        textColor: COLOR.azulOscuro,
+        fontStyle: 'bold',
+        fontSize: 7.8,
+        lineColor: COLOR.azulBorde
+      },
+      showFoot: 'lastPage',
+      didParseCell: data => {
+        alinearNumericasDerecha(data);
+        if (data.section === 'body') {
+          const tipo = tipos[data.row.index];
+          if (tipo === 'proveedor') {
+            data.cell.styles.fillColor = COLOR.filaProveedor;
+            data.cell.styles.fontStyle = 'bold';
+            data.cell.styles.textColor = [33, 97, 140];
+          } else if (data.column.index === 0) {
+            data.cell.styles.textColor = COLOR.grisTexto;
+          }
+        }
+      }
+    }));
+    y = doc.lastAutoTable.finalY + 14;
+  });
+  if (medidas.length === 0) {
+    doc.setFont('helvetica', 'italic');
+    doc.setFontSize(9);
+    doc.setTextColor(...COLOR.grisTexto);
+    doc.text('Sin entradas en este período.', PAGINA.margen, y + 4);
+    y += 24;
+  }
+
+  // ---- Por proveedor
+  y = tituloSeccion(ctx, y, 'Por proveedor', '(compras propias)');
+  if (proveedores.length === 0) {
+    doc.setFont('helvetica', 'italic');
+    doc.setFontSize(9);
+    doc.setTextColor(...COLOR.grisTexto);
+    doc.text('Sin entradas en este período.', PAGINA.margen, y + 4);
+    y += 24;
+  }
+  proveedores.forEach(prov => {
+    y = asegurarEspacio(ctx, y, 90);
+
+    doc.setFillColor(...COLOR.azulSuave);
+    doc.roundedRect(PAGINA.margen, y, PAGINA.ancho - 2 * PAGINA.margen, 20, 3, 3, 'F');
+    doc.setFillColor(...COLOR.verde);
+    doc.roundedRect(PAGINA.margen, y, 3.5, 20, 1.5, 1.5, 'F');
+    doc.setFont('helvetica', 'bold');
+    doc.setFontSize(10.5);
+    doc.setTextColor(...COLOR.azulOscuro);
+    doc.text(prov.nombre, PAGINA.margen + 12, y + 14);
+    doc.setFont('helvetica', 'normal');
+    doc.setFontSize(8);
+    doc.setTextColor(...COLOR.grisTexto);
+    doc.text(
+      [kg(prov.kilos), `${pct(prov.kilos, reporte.totalKilos)} del total`, `${entradasDeProveedorAgrupado(prov)} entradas`].join('  ·  '),
+      PAGINA.ancho - PAGINA.margen - 8,
+      y + 14,
+      { align: 'right' }
+    );
+    y += 26;
+
+    const cuerpo = [];
+    const tipos = [];
+    const porcentajes = [];
+
+    if (prov.proveedoresIndividuales) {
+      prov.proveedoresIndividuales.forEach(indiv => {
+        const entradasIndiv = indiv.medidas.reduce((s, m) => s + m.entradas, 0);
+        cuerpo.push([
+          indiv.nombre,
+          ...reporte.anios.map(a => (indiv.porAnio[a] ? formatNumber(indiv.porAnio[a], 0) : '—')),
+          String(entradasIndiv),
+          ...(mostrarPrecios ? [''] : []),
+          formatNumber(indiv.kilos, 0),
+          pct(indiv.kilos, prov.kilos)
+        ]);
+        tipos.push('proveedor');
+        porcentajes.push(prov.kilos > 0 ? indiv.kilos / prov.kilos : 0);
+        indiv.medidas.forEach(med => {
+          cuerpo.push([
+            `    ${med.nombre}`,
+            ...reporte.anios.map(a => (med.porAnio[a] ? formatNumber(med.porAnio[a], 0) : '—')),
+            String(med.entradas),
+            ...(mostrarPrecios ? [med.precioPromedio ? `$${formatNumber(med.precioPromedio)}` : '—'] : []),
+            formatNumber(med.kilos, 0),
+            pct(med.kilos, indiv.kilos)
+          ]);
+          tipos.push('variante');
+          porcentajes.push(indiv.kilos > 0 ? med.kilos / indiv.kilos : 0);
+        });
+      });
+    } else {
+      prov.medidas.forEach(med => {
+        cuerpo.push([
+          med.nombre,
+          ...reporte.anios.map(a => (med.porAnio[a] ? formatNumber(med.porAnio[a], 0) : '—')),
+          String(med.entradas),
+          ...(mostrarPrecios ? [med.precioPromedio ? `$${formatNumber(med.precioPromedio)}` : '—'] : []),
+          formatNumber(med.kilos, 0),
+          pct(med.kilos, prov.kilos)
+        ]);
+        tipos.push('medida');
+        porcentajes.push(prov.kilos > 0 ? med.kilos / prov.kilos : 0);
+      });
+    }
+
+    const columnaPorcentaje = 1 + reporte.anios.length + 1 + (mostrarPrecios ? 1 : 0) + 1;
+
+    autoTable(doc, opcionesTablaBase(ctx, y, {
+      head: [[
+        'Medida',
+        ...reporte.anios.map(String),
+        'Entradas',
+        ...(mostrarPrecios ? ['Precio prom.'] : []),
+        'Kilos',
+        '% Prov.'
+      ]],
+      body: cuerpo,
+      foot: [[
+        `Total ${prov.nombre}`,
+        ...reporte.anios.map(a => (prov.porAnio[a] ? formatNumber(prov.porAnio[a], 0) : '—')),
+        String(entradasDeProveedorAgrupado(prov)),
+        ...(mostrarPrecios ? [''] : []),
+        formatNumber(prov.kilos, 0),
+        '100%'
+      ]],
+      footStyles: {
+        fillColor: COLOR.azulSuave,
+        textColor: COLOR.azulOscuro,
+        fontStyle: 'bold',
+        fontSize: 7.8,
+        lineColor: COLOR.azulBorde
+      },
+      showFoot: 'lastPage',
+      didParseCell: data => {
+        alinearNumericasDerecha(data);
+        if (data.section === 'body') {
+          const tipo = tipos[data.row.index];
+          if (tipo === 'proveedor') {
+            data.cell.styles.fillColor = COLOR.filaProveedor;
+            data.cell.styles.fontStyle = 'bold';
+            data.cell.styles.textColor = [33, 97, 140];
+          } else if (tipo === 'variante' && data.column.index === 0) {
+            data.cell.styles.textColor = COLOR.grisTexto;
+          }
+        }
+      },
+      willDrawCell: data => {
+        // Micro-barra de porcentaje detrás del texto en la columna % Prov.
+        if (data.section === 'body' && data.column.index === columnaPorcentaje) {
+          const fraccion = porcentajes[data.row.index] || 0;
+          const anchoBarra = Math.max((data.cell.width - 8) * Math.min(fraccion, 1), 0);
+          if (anchoBarra > 0.5) {
+            doc.setFillColor(214, 234, 248);
+            doc.rect(data.cell.x + 4, data.cell.y + 2.5, anchoBarra, data.cell.height - 5, 'F');
+          }
+        }
+      }
+    }));
+    y = doc.lastAutoTable.finalY + 14;
+  });
+
+  // ---- Maquila
+  if (maquilas.length > 0) {
+    y = tituloSeccion(ctx, y, 'Maquila', '(producto de terceros — dimensiona la capacidad de trabajo)', COLOR.naranjaOscuro, COLOR.naranja);
+    maquilas.forEach(maq => {
+      y = asegurarEspacio(ctx, y, 80);
+
+      doc.setFillColor(...COLOR.naranjaSuave);
+      doc.roundedRect(PAGINA.margen, y, PAGINA.ancho - 2 * PAGINA.margen, 20, 3, 3, 'F');
+      doc.setFillColor(...COLOR.naranja);
+      doc.roundedRect(PAGINA.margen, y, 3.5, 20, 1.5, 1.5, 'F');
+      doc.setFont('helvetica', 'bold');
+      doc.setFontSize(10.5);
+      doc.setTextColor(...COLOR.naranjaOscuro);
+      doc.text(`${maq.nombre} (Maquila)`, PAGINA.margen + 12, y + 14);
+      doc.setFont('helvetica', 'normal');
+      doc.setFontSize(8);
+      doc.setTextColor(...COLOR.grisTexto);
+      doc.text(
+        [kg(maq.kilos), `${maq.entradas} entradas`].join('  ·  '),
+        PAGINA.ancho - PAGINA.margen - 8,
+        y + 14,
+        { align: 'right' }
+      );
+      y += 26;
+
+      autoTable(doc, opcionesTablaBase(ctx, y, {
+        head: [['Medida', ...reporte.anios.map(String), 'Entradas', 'Kilos']],
+        headStyles: {
+          fillColor: COLOR.naranja,
+          textColor: 255,
+          fontSize: 7.8,
+          fontStyle: 'bold',
+          lineColor: COLOR.naranja
+        },
+        body: maq.medidas.map(med => [
+          med.nombre,
+          ...reporte.anios.map(a => (med.porAnio[a] ? formatNumber(med.porAnio[a], 0) : '—')),
+          String(med.entradas),
+          formatNumber(med.kilos, 0)
+        ]),
+        foot: [[
+          `Total ${maq.nombre}`,
+          ...reporte.anios.map(a => (maq.porAnio[a] ? formatNumber(maq.porAnio[a], 0) : '—')),
+          String(maq.entradas),
+          formatNumber(maq.kilos, 0)
+        ]],
+        footStyles: {
+          fillColor: COLOR.naranjaSuave,
+          textColor: COLOR.naranjaOscuro,
+          fontStyle: 'bold',
+          fontSize: 7.8,
+          lineColor: [245, 217, 168]
+        },
+        showFoot: 'lastPage',
+        didParseCell: data => alinearNumericasDerecha(data)
+      }));
+      y = doc.lastAutoTable.finalY + 14;
+    });
+  }
+
+  dibujarPiesDePagina(doc);
+  doc.save(nombreArchivo('detallado', rango));
+}

--- a/src/views/ReporteConsumoMedidas.vue
+++ b/src/views/ReporteConsumoMedidas.vue
@@ -1,0 +1,909 @@
+<template>
+  <div class="reporte-consumo">
+    <div class="no-print back-row">
+      <BackButton to="/existencias" />
+    </div>
+
+    <header class="reporte-header">
+      <h1>Reporte de Consumo por Medida</h1>
+      <p class="subtitulo">
+        Entradas de producto del {{ formatearFechaCorta(fechaDesde) }} al {{ formatearFechaCorta(fechaHasta) }}
+        · Rey Pez
+      </p>
+    </header>
+
+    <div class="filtros no-print">
+      <div class="filtro-fechas">
+        <label>
+          Desde
+          <input type="date" v-model="fechaDesde" />
+        </label>
+        <label>
+          Hasta
+          <input type="date" v-model="fechaHasta" />
+        </label>
+      </div>
+      <div class="filtro-rapidos">
+        <button
+          v-for="anio in aniosDisponibles"
+          :key="anio"
+          @click="seleccionarAnio(anio)"
+          :class="{ activo: esRangoAnio(anio) }"
+        >
+          {{ anio }}
+        </button>
+        <button @click="seleccionarTodo" :class="{ activo: esRangoTodo }">2024–Hoy</button>
+      </div>
+      <div class="filtro-extra">
+        <input
+          type="text"
+          v-model="busqueda"
+          placeholder="Filtrar por medida o proveedor"
+          class="busqueda-input"
+        />
+        <label class="check-precios">
+          <input type="checkbox" v-model="mostrarPrecios" />
+          Mostrar precio promedio
+        </label>
+        <button class="btn-imprimir" @click="imprimir">⎙ Imprimir</button>
+      </div>
+    </div>
+
+    <div v-if="cargando" class="estado-carga">Cargando entradas…</div>
+    <div v-else-if="errorCarga" class="estado-error">{{ errorCarga }}</div>
+
+    <template v-else>
+      <div class="tiles">
+        <div class="tile">
+          <span class="tile-label">Compras propias</span>
+          <span class="tile-valor">{{ formatNumber(reporte.totalKilos, 0) }} kg</span>
+          <span class="tile-sub">{{ reporte.totalEntradas }} entradas</span>
+        </div>
+        <div class="tile tile-maquila">
+          <span class="tile-label">Maquila (Ozuna / Joselito)</span>
+          <span class="tile-valor">{{ formatNumber(reporte.maquilaKilos, 0) }} kg</span>
+          <span class="tile-sub">{{ reporte.maquilaEntradas }} entradas</span>
+        </div>
+        <div class="tile tile-total">
+          <span class="tile-label">Volumen total procesado</span>
+          <span class="tile-valor">{{ formatNumber(reporte.totalKilos + reporte.maquilaKilos, 0) }} kg</span>
+          <span class="tile-sub">{{ reporte.totalEntradas + reporte.maquilaEntradas }} entradas</span>
+        </div>
+        <div class="tile" v-for="anio in reporte.anios" :key="`tile-${anio}`">
+          <span class="tile-label">Compras {{ anio }}</span>
+          <span class="tile-valor">{{ formatNumber(reporte.porAnio[anio] || 0, 0) }} kg</span>
+        </div>
+      </div>
+
+      <!-- ============ GLOBAL POR MEDIDA ============ -->
+      <section class="seccion">
+        <h2>Global por medida <span class="seccion-nota">(compras propias, sin maquila)</span></h2>
+        <div v-if="medidasFiltradas.length === 0" class="sin-datos">Sin entradas en este período.</div>
+        <div class="medida-card" v-for="m in medidasFiltradas" :key="m.base">
+          <div class="medida-card-header">
+            <h3>{{ m.base }}</h3>
+            <div class="medida-totales">
+              <strong>{{ formatNumber(m.kilos, 0) }} kg</strong>
+              · {{ formatNumber(porcentaje(m.kilos), 1) }}% del total
+              · {{ m.entradas }} entradas
+              <span v-if="mostrarPrecios && m.precioPromedio">
+                · prom. ${{ formatNumber(m.precioPromedio) }}
+              </span>
+            </div>
+          </div>
+          <table class="tabla">
+            <thead>
+              <tr>
+                <th class="col-nombre">Proveedor / Medida</th>
+                <th v-for="anio in reporte.anios" :key="anio" class="col-num">{{ anio }}</th>
+                <th class="col-num">Entradas</th>
+                <th v-if="mostrarPrecios" class="col-num">Precio prom.</th>
+                <th class="col-num">Kilos</th>
+              </tr>
+            </thead>
+            <tbody>
+              <template v-for="prov in m.proveedores">
+                <tr class="fila-proveedor" :key="`${m.base}-${prov.nombre}`">
+                  <td class="col-nombre">{{ prov.nombre }}</td>
+                  <td v-for="anio in reporte.anios" :key="anio" class="col-num">
+                    {{ prov.porAnio[anio] ? formatNumber(prov.porAnio[anio], 0) : '—' }}
+                  </td>
+                  <td class="col-num">{{ prov.entradas }}</td>
+                  <td v-if="mostrarPrecios" class="col-num precio">
+                    {{ prov.precioPromedio ? `$${formatNumber(prov.precioPromedio)}` : '—' }}
+                  </td>
+                  <td class="col-num"><strong>{{ formatNumber(prov.kilos, 0) }}</strong></td>
+                </tr>
+                <tr
+                  v-for="v in prov.variantes"
+                  :key="`${m.base}-${prov.nombre}-${v.medida}`"
+                  class="fila-variante"
+                >
+                  <td class="col-nombre variante-nombre">{{ v.medida }}</td>
+                  <td v-for="anio in reporte.anios" :key="anio" class="col-num">
+                    {{ v.porAnio[anio] ? formatNumber(v.porAnio[anio], 0) : '—' }}
+                  </td>
+                  <td class="col-num">{{ v.entradas }}</td>
+                  <td v-if="mostrarPrecios" class="col-num precio">
+                    {{ v.precioPromedio ? `$${formatNumber(v.precioPromedio)}` : '—' }}
+                  </td>
+                  <td class="col-num">{{ formatNumber(v.kilos, 0) }}</td>
+                </tr>
+              </template>
+              <tr class="fila-total">
+                <td class="col-nombre">Total {{ m.base }}</td>
+                <td v-for="anio in reporte.anios" :key="anio" class="col-num">
+                  {{ m.porAnio[anio] ? formatNumber(m.porAnio[anio], 0) : '—' }}
+                </td>
+                <td class="col-num">{{ m.entradas }}</td>
+                <td v-if="mostrarPrecios" class="col-num precio">
+                  {{ m.precioPromedio ? `$${formatNumber(m.precioPromedio)}` : '—' }}
+                </td>
+                <td class="col-num">{{ formatNumber(m.kilos, 0) }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <!-- ============ POR PROVEEDOR ============ -->
+      <section class="seccion">
+        <h2>Por proveedor <span class="seccion-nota">(compras propias)</span></h2>
+        <div v-if="proveedoresFiltrados.length === 0" class="sin-datos">Sin entradas en este período.</div>
+        <div class="medida-card" v-for="prov in proveedoresFiltrados" :key="`prov-${prov.nombre}`">
+          <div class="medida-card-header">
+            <h3>{{ prov.nombre }}</h3>
+            <div class="medida-totales">
+              <strong>{{ formatNumber(prov.kilos, 0) }} kg</strong>
+              · {{ formatNumber(porcentaje(prov.kilos), 1) }}% del total
+              · {{ prov.entradas }} entradas
+            </div>
+          </div>
+          <table class="tabla">
+            <thead>
+              <tr>
+                <th class="col-nombre">Medida</th>
+                <th v-for="anio in reporte.anios" :key="anio" class="col-num">{{ anio }}</th>
+                <th class="col-num">Entradas</th>
+                <th v-if="mostrarPrecios" class="col-num">Precio prom.</th>
+                <th class="col-num">Kilos</th>
+                <th class="col-num">% Prov.</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="med in prov.medidas" :key="`prov-${prov.nombre}-${med.nombre}`">
+                <td class="col-nombre">{{ med.nombre }}</td>
+                <td v-for="anio in reporte.anios" :key="anio" class="col-num">
+                  {{ med.porAnio[anio] ? formatNumber(med.porAnio[anio], 0) : '—' }}
+                </td>
+                <td class="col-num">{{ med.entradas }}</td>
+                <td v-if="mostrarPrecios" class="col-num precio">
+                  {{ med.precioPromedio ? `$${formatNumber(med.precioPromedio)}` : '—' }}
+                </td>
+                <td class="col-num">{{ formatNumber(med.kilos, 0) }}</td>
+                <td class="col-num">
+                  {{ prov.kilos > 0 ? formatNumber((med.kilos / prov.kilos) * 100, 1) : '0.0' }}%
+                </td>
+              </tr>
+              <tr class="fila-total">
+                <td class="col-nombre">Total {{ prov.nombre }}</td>
+                <td v-for="anio in reporte.anios" :key="anio" class="col-num">
+                  {{ prov.porAnio[anio] ? formatNumber(prov.porAnio[anio], 0) : '—' }}
+                </td>
+                <td class="col-num">{{ prov.entradas }}</td>
+                <td v-if="mostrarPrecios" class="col-num"></td>
+                <td class="col-num">{{ formatNumber(prov.kilos, 0) }}</td>
+                <td class="col-num">100%</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <!-- ============ MAQUILA (APARTE) ============ -->
+      <section class="seccion seccion-maquila">
+        <h2>
+          Maquila <span class="seccion-nota">(producto de terceros — no es compra propia; dimensiona la capacidad de trabajo)</span>
+        </h2>
+        <div v-if="maquilasFiltradas.length === 0" class="sin-datos">Sin entradas de maquila en este período.</div>
+        <div class="medida-card" v-for="maq in maquilasFiltradas" :key="`maq-${maq.nombre}`">
+          <div class="medida-card-header">
+            <h3>{{ maq.nombre }} (Maquila)</h3>
+            <div class="medida-totales">
+              <strong>{{ formatNumber(maq.kilos, 0) }} kg</strong>
+              · {{ maq.entradas }} entradas
+            </div>
+          </div>
+          <table class="tabla">
+            <thead>
+              <tr>
+                <th class="col-nombre">Medida</th>
+                <th v-for="anio in reporte.anios" :key="anio" class="col-num">{{ anio }}</th>
+                <th class="col-num">Entradas</th>
+                <th class="col-num">Kilos</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="med in maq.medidas" :key="`maq-${maq.nombre}-${med.nombre}`">
+                <td class="col-nombre">{{ med.nombre }}</td>
+                <td v-for="anio in reporte.anios" :key="anio" class="col-num">
+                  {{ med.porAnio[anio] ? formatNumber(med.porAnio[anio], 0) : '—' }}
+                </td>
+                <td class="col-num">{{ med.entradas }}</td>
+                <td class="col-num">{{ formatNumber(med.kilos, 0) }}</td>
+              </tr>
+              <tr class="fila-total">
+                <td class="col-nombre">Total {{ maq.nombre }}</td>
+                <td v-for="anio in reporte.anios" :key="anio" class="col-num">
+                  {{ maq.porAnio[anio] ? formatNumber(maq.porAnio[anio], 0) : '—' }}
+                </td>
+                <td class="col-num">{{ maq.entradas }}</td>
+                <td class="col-num">{{ formatNumber(maq.kilos, 0) }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <!-- ============ MEDIDAS A DEPURAR ============ -->
+      <section class="seccion seccion-depurar" v-if="reporte.sinClasificar.length > 0">
+        <h2>Medidas a depurar <span class="seccion-nota">(no se pudieron agrupar por medida base)</span></h2>
+        <p class="nota-depurar no-print">
+          Estas medidas no empiezan con un número (ej. "Aarón"), así que no entran en el global por medida
+          — aunque sí cuentan en los totales y en la sección por proveedor. Para reasignarlas a un grupo
+          (ej. "51/60"), se agregan al mapa <code>DEPURACION_MEDIDAS</code> de esta vista.
+        </p>
+        <table class="tabla">
+          <thead>
+            <tr>
+              <th class="col-nombre">Medida</th>
+              <th class="col-nombre">Proveedor</th>
+              <th class="col-num">Entradas</th>
+              <th class="col-num">Kilos</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="item in reporte.sinClasificar" :key="`sc-${item.medida}-${item.proveedor}`">
+              <td class="col-nombre">{{ item.medida }}</td>
+              <td class="col-nombre">{{ item.proveedor }}</td>
+              <td class="col-num">{{ item.entradas }}</td>
+              <td class="col-num">{{ formatNumber(item.kilos, 0) }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+    </template>
+  </div>
+</template>
+
+<script>
+import { db } from '@/firebase';
+import { collection, getDocs } from 'firebase/firestore';
+import { formatNumber } from '@/utils/formatters';
+import BackButton from '@/components/BackButton.vue';
+
+// Proveedores que trabajan producto de terceros: se reportan aparte.
+const MAQUILAS = ['Ozuna', 'Joselito'];
+
+// Depuración manual de medidas: medida exacta (tal como está guardada) → grupo
+// al que debe sumarse en el "Global por medida". Las medidas que no empiezan
+// con número y no estén aquí aparecen en la sección "Medidas a depurar".
+// Ejemplo: 'Aarón': '51/60 Otros',
+const DEPURACION_MEDIDAS = {};
+
+function parseFechaSacada(fecha) {
+  if (!fecha) return new Date(0);
+  if (fecha instanceof Date) return fecha;
+  if (typeof fecha.toDate === 'function') return fecha.toDate();
+  const d = new Date(fecha);
+  return isNaN(d.getTime()) ? new Date(0) : d;
+}
+
+function fechaLocalISO(date) {
+  const d = date || new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}
+
+function baseDeMedida(medida) {
+  const depurada = DEPURACION_MEDIDAS[medida];
+  if (depurada) return depurada;
+  const token = medida.split(/\s+/)[0];
+  return /\d/.test(token) ? token : null;
+}
+
+function nuevoAcumulador(extra = {}) {
+  return { kilos: 0, entradas: 0, porAnio: {}, precioSum: 0, precioKilos: 0, ...extra };
+}
+
+function acumular(acc, entrada) {
+  acc.kilos += entrada.kilos;
+  acc.entradas += 1;
+  acc.porAnio[entrada.anio] = (acc.porAnio[entrada.anio] || 0) + entrada.kilos;
+  if (entrada.precio !== null && entrada.precio > 0) {
+    acc.precioSum += entrada.precio * entrada.kilos;
+    acc.precioKilos += entrada.kilos;
+  }
+}
+
+function precioPromedio(acc) {
+  return acc.precioKilos > 0 ? acc.precioSum / acc.precioKilos : null;
+}
+
+export default {
+  name: 'ReporteConsumoMedidas',
+  components: { BackButton },
+  data() {
+    return {
+      cargando: true,
+      errorCarga: null,
+      entradas: [],
+      fechaDesde: '2024-01-01',
+      fechaHasta: fechaLocalISO(),
+      busqueda: '',
+      mostrarPrecios: false
+    };
+  },
+  computed: {
+    aniosDisponibles() {
+      const actual = new Date().getFullYear();
+      const anios = [];
+      for (let a = 2024; a <= actual; a += 1) anios.push(a);
+      return anios;
+    },
+    esRangoTodo() {
+      return this.fechaDesde === '2024-01-01' && this.fechaHasta === fechaLocalISO();
+    },
+    reporte() {
+      const desde = this.fechaDesde ? new Date(`${this.fechaDesde}T00:00:00`) : null;
+      const hasta = this.fechaHasta ? new Date(`${this.fechaHasta}T23:59:59.999`) : null;
+
+      const r = {
+        totalKilos: 0,
+        totalEntradas: 0,
+        porAnio: {},
+        maquilaKilos: 0,
+        maquilaEntradas: 0,
+        anios: [],
+        medidas: [],
+        proveedores: [],
+        maquilas: [],
+        sinClasificar: []
+      };
+
+      const medidas = {};
+      const proveedores = {};
+      const maquilas = {};
+      const sinClasificar = {};
+      const anios = new Set();
+
+      this.entradas.forEach(entrada => {
+        if (desde && entrada.fecha < desde) return;
+        if (hasta && entrada.fecha > hasta) return;
+        anios.add(entrada.anio);
+
+        if (entrada.esMaquila) {
+          r.maquilaKilos += entrada.kilos;
+          r.maquilaEntradas += 1;
+          if (!maquilas[entrada.proveedor]) {
+            maquilas[entrada.proveedor] = nuevoAcumulador({ nombre: entrada.proveedor, medidas: {} });
+          }
+          const maq = maquilas[entrada.proveedor];
+          acumular(maq, entrada);
+          if (!maq.medidas[entrada.medida]) {
+            maq.medidas[entrada.medida] = nuevoAcumulador({ nombre: entrada.medida });
+          }
+          acumular(maq.medidas[entrada.medida], entrada);
+          return;
+        }
+
+        r.totalKilos += entrada.kilos;
+        r.totalEntradas += 1;
+        r.porAnio[entrada.anio] = (r.porAnio[entrada.anio] || 0) + entrada.kilos;
+
+        const base = baseDeMedida(entrada.medida);
+        const baseProveedor = base || entrada.medida;
+
+        if (!proveedores[entrada.proveedor]) {
+          proveedores[entrada.proveedor] = nuevoAcumulador({ nombre: entrada.proveedor, medidas: {} });
+        }
+        const prov = proveedores[entrada.proveedor];
+        acumular(prov, entrada);
+        if (!prov.medidas[baseProveedor]) {
+          prov.medidas[baseProveedor] = nuevoAcumulador({ nombre: baseProveedor });
+        }
+        acumular(prov.medidas[baseProveedor], entrada);
+
+        if (!base) {
+          const clave = `${entrada.medida}||${entrada.proveedor}`;
+          if (!sinClasificar[clave]) {
+            sinClasificar[clave] = nuevoAcumulador({ medida: entrada.medida, proveedor: entrada.proveedor });
+          }
+          acumular(sinClasificar[clave], entrada);
+          return;
+        }
+
+        if (!medidas[base]) {
+          medidas[base] = nuevoAcumulador({ base, proveedores: {} });
+        }
+        const med = medidas[base];
+        acumular(med, entrada);
+        if (!med.proveedores[entrada.proveedor]) {
+          med.proveedores[entrada.proveedor] = nuevoAcumulador({ nombre: entrada.proveedor, variantes: {} });
+        }
+        const medProv = med.proveedores[entrada.proveedor];
+        acumular(medProv, entrada);
+        if (!medProv.variantes[entrada.medida]) {
+          medProv.variantes[entrada.medida] = nuevoAcumulador({ medida: entrada.medida });
+        }
+        acumular(medProv.variantes[entrada.medida], entrada);
+      });
+
+      const porKilosDesc = (a, b) => b.kilos - a.kilos;
+
+      r.anios = Array.from(anios).sort();
+      r.medidas = Object.values(medidas)
+        .map(med => ({
+          ...med,
+          precioPromedio: precioPromedio(med),
+          proveedores: Object.values(med.proveedores)
+            .map(prov => ({
+              ...prov,
+              precioPromedio: precioPromedio(prov),
+              variantes: Object.values(prov.variantes)
+                .map(v => ({ ...v, precioPromedio: precioPromedio(v) }))
+                .sort(porKilosDesc)
+            }))
+            .sort(porKilosDesc)
+        }))
+        .sort(porKilosDesc);
+      r.proveedores = Object.values(proveedores)
+        .map(prov => ({
+          ...prov,
+          medidas: Object.values(prov.medidas)
+            .map(med => ({ ...med, precioPromedio: precioPromedio(med) }))
+            .sort(porKilosDesc)
+        }))
+        .sort(porKilosDesc);
+      r.maquilas = Object.values(maquilas)
+        .map(maq => ({ ...maq, medidas: Object.values(maq.medidas).sort(porKilosDesc) }))
+        .sort(porKilosDesc);
+      r.sinClasificar = Object.values(sinClasificar).sort(porKilosDesc);
+
+      return r;
+    },
+    medidasFiltradas() {
+      const q = this.busqueda.trim().toLowerCase();
+      if (!q) return this.reporte.medidas;
+      return this.reporte.medidas.filter(m =>
+        m.base.toLowerCase().includes(q) ||
+        m.proveedores.some(prov =>
+          prov.nombre.toLowerCase().includes(q) ||
+          prov.variantes.some(v => v.medida.toLowerCase().includes(q))
+        )
+      );
+    },
+    proveedoresFiltrados() {
+      const q = this.busqueda.trim().toLowerCase();
+      if (!q) return this.reporte.proveedores;
+      return this.reporte.proveedores.filter(prov =>
+        prov.nombre.toLowerCase().includes(q) ||
+        prov.medidas.some(med => med.nombre.toLowerCase().includes(q))
+      );
+    },
+    maquilasFiltradas() {
+      const q = this.busqueda.trim().toLowerCase();
+      if (!q) return this.reporte.maquilas;
+      return this.reporte.maquilas.filter(maq =>
+        maq.nombre.toLowerCase().includes(q) ||
+        maq.medidas.some(med => med.nombre.toLowerCase().includes(q))
+      );
+    }
+  },
+  async mounted() {
+    await this.cargarEntradas();
+  },
+  methods: {
+    formatNumber,
+    formatearFechaCorta(iso) {
+      if (!iso) return '';
+      const [anio, mes, dia] = iso.split('-');
+      return `${dia}/${mes}/${anio}`;
+    },
+    porcentaje(kilos) {
+      return this.reporte.totalKilos > 0 ? (kilos / this.reporte.totalKilos) * 100 : 0;
+    },
+    seleccionarAnio(anio) {
+      this.fechaDesde = `${anio}-01-01`;
+      const hoy = fechaLocalISO();
+      const finAnio = `${anio}-12-31`;
+      this.fechaHasta = finAnio < hoy ? finAnio : hoy;
+    },
+    esRangoAnio(anio) {
+      return this.fechaDesde === `${anio}-01-01` &&
+        (this.fechaHasta === `${anio}-12-31` || (String(new Date().getFullYear()) === String(anio) && this.fechaHasta === fechaLocalISO()));
+    },
+    seleccionarTodo() {
+      this.fechaDesde = '2024-01-01';
+      this.fechaHasta = fechaLocalISO();
+    },
+    imprimir() {
+      window.print();
+    },
+    async cargarEntradas() {
+      this.cargando = true;
+      this.errorCarga = null;
+      try {
+        const snapshot = await getDocs(collection(db, 'sacadas'));
+        const entradas = [];
+        snapshot.docs.forEach(docSnap => {
+          const sacada = docSnap.data();
+          const fecha = parseFechaSacada(sacada.fecha);
+          (sacada.entradas || []).forEach(entrada => {
+            const medida = String(entrada.medida || '').trim();
+            const proveedor = String(entrada.proveedor || '').trim() || 'Sin proveedor';
+            const kilos = Number(entrada.kilos) || 0;
+            if (!medida || kilos <= 0) return;
+            entradas.push({
+              fecha,
+              anio: fecha.getFullYear(),
+              medida,
+              proveedor,
+              kilos,
+              precio: entrada.precio !== null && entrada.precio !== undefined ? Number(entrada.precio) : null,
+              esMaquila: entrada.tipo === 'maquila' || MAQUILAS.includes(proveedor)
+            });
+          });
+        });
+        this.entradas = entradas;
+      } catch (error) {
+        console.error('Error al cargar entradas para el reporte de consumo:', error);
+        this.errorCarga = 'No se pudieron cargar las entradas. Revisa la conexión e intenta de nuevo.';
+      } finally {
+        this.cargando = false;
+      }
+    }
+  }
+};
+</script>
+
+<style scoped>
+.reporte-consumo {
+  max-width: 1100px;
+  margin: 14px auto 50px;
+  padding: 8px 20px 40px;
+  background: #f7fafc;
+  border-radius: 10px;
+  color: #2c3e50;
+  font-family: 'Segoe UI', Arial, sans-serif;
+}
+
+.back-row {
+  padding-top: 4px;
+}
+
+.reporte-header {
+  text-align: center;
+  margin-bottom: 18px;
+}
+
+.reporte-header h1 {
+  margin: 0 0 4px;
+  font-size: 1.9rem;
+  color: #1a5276;
+}
+
+.subtitulo {
+  margin: 0;
+  color: #6c7a89;
+  font-size: 0.95rem;
+}
+
+.filtros {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+  justify-content: center;
+  background: #f4f8fb;
+  border: 1px solid #d6e4ef;
+  border-radius: 8px;
+  padding: 12px 16px;
+  margin-bottom: 20px;
+}
+
+.filtro-fechas {
+  display: flex;
+  gap: 12px;
+}
+
+.filtro-fechas label {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.8rem;
+  color: #5d6d7e;
+  gap: 2px;
+}
+
+.filtro-fechas input,
+.busqueda-input {
+  padding: 6px 8px;
+  border: 1px solid #b0c4d4;
+  border-radius: 5px;
+  font-size: 0.9rem;
+}
+
+.filtro-rapidos {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.filtro-rapidos button {
+  padding: 6px 12px;
+  border: 1px solid #2980b9;
+  border-radius: 5px;
+  background: white;
+  color: #2980b9;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.filtro-rapidos button.activo,
+.filtro-rapidos button:hover {
+  background: #2980b9;
+  color: white;
+}
+
+.filtro-extra {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.busqueda-input {
+  min-width: 220px;
+}
+
+.check-precios {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.85rem;
+  color: #5d6d7e;
+  cursor: pointer;
+}
+
+.btn-imprimir {
+  padding: 7px 14px;
+  border: none;
+  border-radius: 5px;
+  background: #27ae60;
+  color: white;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.btn-imprimir:hover {
+  background: #219653;
+}
+
+.estado-carga,
+.estado-error,
+.sin-datos {
+  text-align: center;
+  padding: 30px 10px;
+  color: #6c7a89;
+}
+
+.estado-error {
+  color: #c0392b;
+}
+
+.tiles {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 26px;
+}
+
+.tile {
+  flex: 1 1 160px;
+  background: #eaf2f8;
+  border: 1px solid #c8dbe9;
+  border-radius: 8px;
+  padding: 10px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.tile-maquila {
+  background: #fef5e7;
+  border-color: #f5d9a8;
+}
+
+.tile-total {
+  background: #e8f8f0;
+  border-color: #b8e6ce;
+}
+
+.tile-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: #5d6d7e;
+}
+
+.tile-valor {
+  font-size: 1.3rem;
+  font-weight: 700;
+  color: #1a5276;
+}
+
+.tile-sub {
+  font-size: 0.8rem;
+  color: #6c7a89;
+}
+
+.seccion {
+  margin-bottom: 34px;
+}
+
+.seccion h2 {
+  color: #1a5276;
+  border-bottom: 2px solid #2980b9;
+  padding-bottom: 6px;
+  margin-bottom: 14px;
+  font-size: 1.3rem;
+}
+
+.seccion-maquila h2 {
+  color: #9c640c;
+  border-bottom-color: #e67e22;
+}
+
+.seccion-depurar h2 {
+  color: #922b21;
+  border-bottom-color: #c0392b;
+}
+
+.seccion-nota {
+  font-size: 0.8rem;
+  font-weight: 400;
+  color: #6c7a89;
+}
+
+.nota-depurar {
+  font-size: 0.85rem;
+  color: #6c7a89;
+  margin: 0 0 10px;
+}
+
+.medida-card {
+  background: white;
+  border: 1px solid #d6e4ef;
+  border-radius: 8px;
+  padding: 12px 14px 6px;
+  margin-bottom: 16px;
+  box-shadow: 0 1px 3px rgba(26, 82, 118, 0.08);
+}
+
+.medida-card-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.medida-card-header h3 {
+  margin: 0;
+  font-size: 1.15rem;
+  color: #21618c;
+}
+
+.medida-totales {
+  font-size: 0.9rem;
+  color: #5d6d7e;
+}
+
+.medida-totales strong {
+  color: #1a5276;
+}
+
+.tabla {
+  width: 100%;
+  border-collapse: collapse;
+  background: white;
+  font-size: 0.88rem;
+  margin-bottom: 8px;
+}
+
+.tabla th {
+  background: #f4f8fb;
+  color: #34495e;
+  text-align: left;
+  padding: 6px 8px;
+  border-bottom: 2px solid #d6e4ef;
+}
+
+.tabla td {
+  padding: 5px 8px;
+  border-bottom: 1px solid #edf3f8;
+}
+
+.col-num {
+  text-align: right;
+  white-space: nowrap;
+}
+
+th.col-num {
+  text-align: right;
+}
+
+.fila-proveedor td {
+  background: #f8fbfd;
+  font-weight: 600;
+  color: #21618c;
+  border-top: 1px solid #d6e4ef;
+}
+
+.variante-nombre {
+  padding-left: 24px;
+  color: #5d6d7e;
+}
+
+.fila-total td {
+  background: #eaf2f8;
+  font-weight: 700;
+  color: #1a5276;
+  border-top: 2px solid #2980b9;
+}
+
+.precio {
+  color: #27ae60;
+  font-weight: 600;
+}
+
+@media (max-width: 700px) {
+  .tabla {
+    font-size: 0.78rem;
+  }
+
+  .tabla th,
+  .tabla td {
+    padding: 4px 5px;
+  }
+
+  .reporte-header h1 {
+    font-size: 1.4rem;
+  }
+}
+
+@media print {
+  .no-print {
+    display: none !important;
+  }
+
+  .reporte-consumo {
+    max-width: none;
+    padding: 0;
+  }
+
+  .medida-card {
+    box-shadow: none;
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  .tiles {
+    gap: 6px;
+  }
+
+  .tabla {
+    font-size: 10pt;
+  }
+}
+</style>

--- a/src/views/ReporteConsumoMedidas.vue
+++ b/src/views/ReporteConsumoMedidas.vue
@@ -393,15 +393,20 @@ import BackButton from '@/components/BackButton.vue';
 // Proveedores que trabajan producto de terceros: se reportan aparte.
 const MAQUILAS = ['Ozuna', 'Joselito'];
 
-// Depuración manual de medidas: medida exacta (tal como está guardada) → grupo
-// al que debe sumarse en el "Global por medida". Las medidas que no empiezan
-// con número y no estén aquí aparecen en la sección "Medidas a depurar".
-// Ejemplo: 'Aarón': '51/60 Otros',
+// Depuración manual de medidas: medida exacta (tal como está guardada) →
+// medida con la que debe reportarse. Las entradas con estas medidas se suman
+// como si tuvieran el nombre depurado (en el global, por proveedor y en el
+// desglose). Las medidas que no empiezan con número y no estén aquí aparecen
+// en la sección "Medidas a depurar".
 const DEPURACION_MEDIDAS = {
   '51/60 chuy': '51/60',
-  '51/60 nueva': '51/60',
-  '51/60 Chuy': '51/60'
+  '51/60 Chuy': '51/60',
+  '51/60 nueva': '51/60'
 };
+
+function medidaDepurada(medida) {
+  return DEPURACION_MEDIDAS[medida] || medida;
+}
 
 // Agrupación de proveedores: mapea nombres de proveedores a su grupo.
 // En la sección "Por proveedor", los proveedores del mismo grupo se muestran
@@ -426,9 +431,7 @@ function fechaLocalISO(date) {
 }
 
 function baseDeMedida(medida) {
-  const depurada = DEPURACION_MEDIDAS[medida];
-  if (depurada) return depurada;
-  const token = medida.split(/\s+/)[0];
+  const token = medidaDepurada(medida).split(/\s+/)[0];
   return /\d/.test(token) ? token : null;
 }
 
@@ -508,6 +511,8 @@ export default {
         if (hasta && entrada.fecha > hasta) return;
         anios.add(entrada.anio);
 
+        const medida = medidaDepurada(entrada.medida);
+
         if (entrada.esMaquila) {
           r.maquilaKilos += entrada.kilos;
           r.maquilaEntradas += 1;
@@ -516,10 +521,10 @@ export default {
           }
           const maq = maquilas[entrada.proveedor];
           acumular(maq, entrada);
-          if (!maq.medidas[entrada.medida]) {
-            maq.medidas[entrada.medida] = nuevoAcumulador({ nombre: entrada.medida });
+          if (!maq.medidas[medida]) {
+            maq.medidas[medida] = nuevoAcumulador({ nombre: medida });
           }
-          acumular(maq.medidas[entrada.medida], entrada);
+          acumular(maq.medidas[medida], entrada);
           return;
         }
 
@@ -527,8 +532,8 @@ export default {
         r.totalEntradas += 1;
         r.porAnio[entrada.anio] = (r.porAnio[entrada.anio] || 0) + entrada.kilos;
 
-        const base = baseDeMedida(entrada.medida);
-        const baseProveedor = base || entrada.medida;
+        const base = baseDeMedida(medida);
+        const baseProveedor = base || medida;
 
         if (!proveedores[entrada.proveedor]) {
           proveedores[entrada.proveedor] = nuevoAcumulador({ nombre: entrada.proveedor, medidas: {} });
@@ -541,9 +546,9 @@ export default {
         acumular(prov.medidas[baseProveedor], entrada);
 
         if (!base) {
-          const clave = `${entrada.medida}||${entrada.proveedor}`;
+          const clave = `${medida}||${entrada.proveedor}`;
           if (!sinClasificar[clave]) {
-            sinClasificar[clave] = nuevoAcumulador({ medida: entrada.medida, proveedor: entrada.proveedor });
+            sinClasificar[clave] = nuevoAcumulador({ medida, proveedor: entrada.proveedor });
           }
           acumular(sinClasificar[clave], entrada);
           return;
@@ -559,10 +564,10 @@ export default {
         }
         const medProv = med.proveedores[entrada.proveedor];
         acumular(medProv, entrada);
-        if (!medProv.variantes[entrada.medida]) {
-          medProv.variantes[entrada.medida] = nuevoAcumulador({ medida: entrada.medida });
+        if (!medProv.variantes[medida]) {
+          medProv.variantes[medida] = nuevoAcumulador({ medida });
         }
-        acumular(medProv.variantes[entrada.medida], entrada);
+        acumular(medProv.variantes[medida], entrada);
       });
 
       const porKilosDesc = (a, b) => b.kilos - a.kilos;
@@ -674,11 +679,12 @@ export default {
           if (hasta && e.fecha > hasta) return false;
           if (d.esMaquila !== undefined && e.esMaquila !== d.esMaquila) return false;
           if (d.proveedor && e.proveedor !== d.proveedor) return false;
-          if (d.medidaExacta && e.medida !== d.medidaExacta) return false;
-          if (d.base && baseDeMedida(e.medida) !== d.base) return false;
+          const medida = medidaDepurada(e.medida);
+          if (d.medidaExacta && medida !== d.medidaExacta) return false;
+          if (d.base && baseDeMedida(medida) !== d.base) return false;
           // "grupo" es la fila de la sección por proveedor: medida base, o la
           // medida completa cuando no se pudo clasificar.
-          if (d.grupo && (baseDeMedida(e.medida) || e.medida) !== d.grupo) return false;
+          if (d.grupo && (baseDeMedida(medida) || medida) !== d.grupo) return false;
           return true;
         })
         .sort((a, b) => a.fecha - b.fecha);

--- a/src/views/ReporteConsumoMedidas.vue
+++ b/src/views/ReporteConsumoMedidas.vue
@@ -305,39 +305,6 @@
         </div>
       </section>
 
-      <!-- ============ MEDIDAS A DEPURAR ============ -->
-      <section class="seccion seccion-depurar" v-if="reporte.sinClasificar.length > 0">
-        <h2>Medidas a depurar <span class="seccion-nota">(no se pudieron agrupar por medida base)</span></h2>
-        <p class="nota-depurar no-print">
-          Estas medidas no empiezan con un número (ej. "Aarón"), así que no entran en el global por medida
-          — aunque sí cuentan en los totales y en la sección por proveedor. Para reasignarlas a un grupo
-          (ej. "51/60"), se agregan al mapa <code>DEPURACION_MEDIDAS</code> de esta vista.
-        </p>
-        <table class="tabla">
-          <thead>
-            <tr>
-              <th class="col-nombre">Medida</th>
-              <th class="col-nombre">Proveedor</th>
-              <th class="col-num">Entradas</th>
-              <th class="col-num">Kilos</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr
-              v-for="item in reporte.sinClasificar"
-              :key="`sc-${item.medida}-${item.proveedor}`"
-              class="fila-clic"
-              title="Clic para ver el desglose por fecha"
-              @click="abrirDetalle({ titulo: `${item.medida} · ${item.proveedor}`, proveedor: item.proveedor, medidaExacta: item.medida, esMaquila: false })"
-            >
-              <td class="col-nombre">{{ item.medida }}</td>
-              <td class="col-nombre">{{ item.proveedor }}</td>
-              <td class="col-num">{{ item.entradas }}</td>
-              <td class="col-num">{{ formatNumber(item.kilos, 0) }}</td>
-            </tr>
-          </tbody>
-        </table>
-      </section>
     </template>
 
     <!-- ============ MODAL DE DESGLOSE POR FECHA ============ -->
@@ -998,21 +965,10 @@ export default {
   border-bottom-color: #e67e22;
 }
 
-.seccion-depurar h2 {
-  color: #922b21;
-  border-bottom-color: #c0392b;
-}
-
 .seccion-nota {
   font-size: 0.8rem;
   font-weight: 400;
   color: #6c7a89;
-}
-
-.nota-depurar {
-  font-size: 0.85rem;
-  color: #6c7a89;
-  margin: 0 0 10px;
 }
 
 .medida-card {

--- a/src/views/ReporteConsumoMedidas.vue
+++ b/src/views/ReporteConsumoMedidas.vue
@@ -399,15 +399,15 @@ const MAQUILAS = ['Ozuna', 'Joselito'];
 // sección "Medidas a depurar".
 const DEPURACION_MEDIDAS = {};
 
-// Regla general de depuración: si la medida empieza con la talla (ej. "51/60")
-// y NO dice "1ra Nacional", se considera la medida original y se reporta solo
-// con la talla ("51/60 chuy", "51/60 Tirado" → "51/60"). Si dice "1ra
+// Regla general de depuración: la primera palabra de la medida (ej. "51/60",
+// "Mixta", "Piojo") es la base. Si el resto NO dice "1ra Nacional", se
+// considera la medida original y se reporta solo con la base ("51/60 chuy",
+// "Mixta chuy", "Piojo chuy" → "51/60", "Mixta", "Piojo"). Si dice "1ra
 // Nacional" se conserva como esa variante, con el nombre normalizado.
 function medidaDepurada(medida) {
   const manual = DEPURACION_MEDIDAS[medida];
   if (manual) return manual;
   const token = medida.split(/\s+/)[0];
-  if (!/\d/.test(token)) return medida;
   if (/1ra\s+nacional/i.test(medida)) return `${token} 1ra Nacional`;
   return token;
 }

--- a/src/views/ReporteConsumoMedidas.vue
+++ b/src/views/ReporteConsumoMedidas.vue
@@ -394,18 +394,22 @@ import BackButton from '@/components/BackButton.vue';
 const MAQUILAS = ['Ozuna', 'Joselito'];
 
 // Depuración manual de medidas: medida exacta (tal como está guardada) →
-// medida con la que debe reportarse. Las entradas con estas medidas se suman
-// como si tuvieran el nombre depurado (en el global, por proveedor y en el
-// desglose). Las medidas que no empiezan con número y no estén aquí aparecen
-// en la sección "Medidas a depurar".
-const DEPURACION_MEDIDAS = {
-  '51/60 chuy': '51/60',
-  '51/60 Chuy': '51/60',
-  '51/60 nueva': '51/60'
-};
+// medida con la que debe reportarse. Útil para medidas que no empiezan con
+// número (ej. 'Aarón': '51/60'); las que no estén aquí aparecen en la
+// sección "Medidas a depurar".
+const DEPURACION_MEDIDAS = {};
 
+// Regla general de depuración: si la medida empieza con la talla (ej. "51/60")
+// y NO dice "1ra Nacional", se considera la medida original y se reporta solo
+// con la talla ("51/60 chuy", "51/60 Tirado" → "51/60"). Si dice "1ra
+// Nacional" se conserva como esa variante, con el nombre normalizado.
 function medidaDepurada(medida) {
-  return DEPURACION_MEDIDAS[medida] || medida;
+  const manual = DEPURACION_MEDIDAS[medida];
+  if (manual) return manual;
+  const token = medida.split(/\s+/)[0];
+  if (!/\d/.test(token)) return medida;
+  if (/1ra\s+nacional/i.test(medida)) return `${token} 1ra Nacional`;
+  return token;
 }
 
 // Agrupación de proveedores: mapea nombres de proveedores a su grupo.

--- a/src/views/ReporteConsumoMedidas.vue
+++ b/src/views/ReporteConsumoMedidas.vue
@@ -399,17 +399,28 @@ const MAQUILAS = ['Ozuna', 'Joselito'];
 // sección "Medidas a depurar".
 const DEPURACION_MEDIDAS = {};
 
+// Calificativos que SÍ marcan una variante real (se mantienen separados de
+// la base). Cualquier otro calificativo ("chuy", "nueva", "gde", "café",
+// "Tirado", etc.) se considera la misma medida original y se fusiona con la
+// base. Para agregar una nueva variante a mantener aparte, añade su patrón
+// aquí.
+const VARIANTES_A_CONSERVAR = [
+  { patron: /1ra\s+nacional/i, etiqueta: '1ra Nacional' },
+  { patron: /cristal/i, etiqueta: 'Cristal' }
+];
+
 // Regla general de depuración: la primera palabra de la medida (ej. "51/60",
-// "Mixta", "Piojo") es la base. Si el resto NO dice "1ra Nacional", se
-// considera la medida original y se reporta solo con la base ("51/60 chuy",
-// "Mixta chuy", "Piojo chuy" → "51/60", "Mixta", "Piojo"). Si dice "1ra
-// Nacional" se conserva como esa variante, con el nombre normalizado.
+// "Mixta", "Piojo") es la base. Si el resto no coincide con ninguna
+// variante de VARIANTES_A_CONSERVAR, se considera la medida original y se
+// reporta solo con la base ("51/60 chuy", "Piojo gde", "Piojo café" →
+// "51/60", "Piojo"). Si coincide, se conserva como esa variante, con el
+// nombre normalizado ("Piojo cristal" → "Piojo Cristal").
 function medidaDepurada(medida) {
   const manual = DEPURACION_MEDIDAS[medida];
   if (manual) return manual;
   const token = medida.split(/\s+/)[0];
-  if (/1ra\s+nacional/i.test(medida)) return `${token} 1ra Nacional`;
-  return token;
+  const variante = VARIANTES_A_CONSERVAR.find(v => v.patron.test(medida));
+  return variante ? `${token} ${variante.etiqueta}` : token;
 }
 
 // Agrupación de proveedores: mapea nombres de proveedores a su grupo.

--- a/src/views/ReporteConsumoMedidas.vue
+++ b/src/views/ReporteConsumoMedidas.vue
@@ -156,8 +156,8 @@
       <!-- ============ POR PROVEEDOR ============ -->
       <section class="seccion">
         <h2>Por proveedor <span class="seccion-nota">(compras propias)</span></h2>
-        <div v-if="proveedoresFiltrados.length === 0" class="sin-datos">Sin entradas en este período.</div>
-        <div class="medida-card" v-for="prov in proveedoresFiltrados" :key="`prov-${prov.nombre}`">
+        <div v-if="proveedoresAgrupados.length === 0" class="sin-datos">Sin entradas en este período.</div>
+        <div class="medida-card" v-for="prov in proveedoresAgrupados" :key="`prov-${prov.nombre}`">
           <div class="medida-card-header">
             <h3>{{ prov.nombre }}</h3>
             <div class="medida-totales">
@@ -178,26 +178,67 @@
               </tr>
             </thead>
             <tbody>
-              <tr
-                v-for="med in prov.medidas"
-                :key="`prov-${prov.nombre}-${med.nombre}`"
-                class="fila-clic"
-                title="Clic para ver el desglose por fecha"
-                @click="abrirDetalle({ titulo: `${prov.nombre} · ${med.nombre}`, proveedor: prov.nombre, grupo: med.nombre, esMaquila: false })"
-              >
-                <td class="col-nombre">{{ med.nombre }}</td>
-                <td v-for="anio in reporte.anios" :key="anio" class="col-num">
-                  {{ med.porAnio[anio] ? formatNumber(med.porAnio[anio], 0) : '—' }}
-                </td>
-                <td class="col-num">{{ med.entradas }}</td>
-                <td v-if="mostrarPrecios" class="col-num precio">
-                  {{ med.precioPromedio ? `$${formatNumber(med.precioPromedio)}` : '—' }}
-                </td>
-                <td class="col-num">{{ formatNumber(med.kilos, 0) }}</td>
-                <td class="col-num">
-                  {{ prov.kilos > 0 ? formatNumber((med.kilos / prov.kilos) * 100, 1) : '0.0' }}%
-                </td>
-              </tr>
+              <!-- Proveedores individuales en el grupo (si hay) -->
+              <template v-if="prov.proveedoresIndividuales">
+                <template v-for="indiv in prov.proveedoresIndividuales">
+                  <tr
+                    :key="`prov-${indiv.nombre}`"
+                    class="fila-proveedor"
+                  >
+                    <td class="col-nombre">{{ indiv.nombre }}</td>
+                    <td v-for="anio in reporte.anios" :key="anio" class="col-num">
+                      {{ indiv.porAnio[anio] ? formatNumber(indiv.porAnio[anio], 0) : '—' }}
+                    </td>
+                    <td class="col-num">{{ indiv.medidas.reduce((s, m) => s + m.entradas, 0) }}</td>
+                    <td v-if="mostrarPrecios" class="col-num"></td>
+                    <td class="col-num"><strong>{{ formatNumber(indiv.kilos, 0) }}</strong></td>
+                    <td class="col-num">{{ formatNumber((indiv.kilos / prov.kilos) * 100, 1) }}%</td>
+                  </tr>
+                  <tr
+                    v-for="med in indiv.medidas"
+                    :key="`prov-${indiv.nombre}-${med.nombre}`"
+                    class="fila-variante fila-clic"
+                    title="Clic para ver el desglose por fecha"
+                    @click="abrirDetalle({ titulo: `${indiv.nombre} · ${med.nombre}`, proveedor: indiv.nombre, grupo: med.nombre, esMaquila: false })"
+                  >
+                    <td class="col-nombre variante-nombre">{{ med.nombre }}</td>
+                    <td v-for="anio in reporte.anios" :key="anio" class="col-num">
+                      {{ med.porAnio[anio] ? formatNumber(med.porAnio[anio], 0) : '—' }}
+                    </td>
+                    <td class="col-num">{{ med.entradas }}</td>
+                    <td v-if="mostrarPrecios" class="col-num precio">
+                      {{ med.precioPromedio ? `$${formatNumber(med.precioPromedio)}` : '—' }}
+                    </td>
+                    <td class="col-num">{{ formatNumber(med.kilos, 0) }}</td>
+                    <td class="col-num">
+                      {{ indiv.kilos > 0 ? formatNumber((med.kilos / indiv.kilos) * 100, 1) : '0.0' }}%
+                    </td>
+                  </tr>
+                </template>
+              </template>
+              <!-- Proveedores sin agrupar (mostrar medidas directamente) -->
+              <template v-else>
+                <tr
+                  v-for="med in prov.medidas"
+                  :key="`prov-${prov.nombre}-${med.nombre}`"
+                  class="fila-clic"
+                  title="Clic para ver el desglose por fecha"
+                  @click="abrirDetalle({ titulo: `${prov.nombre} · ${med.nombre}`, proveedor: prov.nombre, grupo: med.nombre, esMaquila: false })"
+                >
+                  <td class="col-nombre">{{ med.nombre }}</td>
+                  <td v-for="anio in reporte.anios" :key="anio" class="col-num">
+                    {{ med.porAnio[anio] ? formatNumber(med.porAnio[anio], 0) : '—' }}
+                  </td>
+                  <td class="col-num">{{ med.entradas }}</td>
+                  <td v-if="mostrarPrecios" class="col-num precio">
+                    {{ med.precioPromedio ? `$${formatNumber(med.precioPromedio)}` : '—' }}
+                  </td>
+                  <td class="col-num">{{ formatNumber(med.kilos, 0) }}</td>
+                  <td class="col-num">
+                    {{ prov.kilos > 0 ? formatNumber((med.kilos / prov.kilos) * 100, 1) : '0.0' }}%
+                  </td>
+                </tr>
+              </template>
               <tr class="fila-total">
                 <td class="col-nombre">Total {{ prov.nombre }}</td>
                 <td v-for="anio in reporte.anios" :key="anio" class="col-num">
@@ -356,7 +397,20 @@ const MAQUILAS = ['Ozuna', 'Joselito'];
 // al que debe sumarse en el "Global por medida". Las medidas que no empiezan
 // con número y no estén aquí aparecen en la sección "Medidas a depurar".
 // Ejemplo: 'Aarón': '51/60 Otros',
-const DEPURACION_MEDIDAS = {};
+const DEPURACION_MEDIDAS = {
+  '51/60 chuy': '51/60',
+  '51/60 nueva': '51/60',
+  '51/60 Chuy': '51/60'
+};
+
+// Agrupación de proveedores: mapea nombres de proveedores a su grupo.
+// En la sección "Por proveedor", los proveedores del mismo grupo se muestran
+// juntos con desglose individual dentro del grupo.
+// Ej: { 'Ahumada': 'Ahumada / Vayon', 'Vayon': 'Ahumada / Vayon' }
+const PROVEEDORES_GRUPO = {
+  'Ahumada': 'Ahumada / Vayon',
+  'Vayon': 'Ahumada / Vayon'
+};
 
 function parseFechaSacada(fecha) {
   if (!fecha) return new Date(0);
@@ -570,6 +624,45 @@ export default {
         maq.nombre.toLowerCase().includes(q) ||
         maq.medidas.some(med => med.nombre.toLowerCase().includes(q))
       );
+    },
+    proveedoresAgrupados() {
+      const grupos = {};
+      const proveedoresIndividuales = [];
+
+      this.proveedoresFiltrados.forEach(prov => {
+        const nombreGrupo = PROVEEDORES_GRUPO[prov.nombre];
+        if (nombreGrupo) {
+          if (!grupos[nombreGrupo]) {
+            grupos[nombreGrupo] = {
+              nombre: nombreGrupo,
+              kilos: 0,
+              entradas: 0,
+              porAnio: {},
+              medidas: [],
+              proveedoresIndividuales: []
+            };
+          }
+          const grupo = grupos[nombreGrupo];
+          grupo.kilos += prov.kilos;
+          grupo.entradas += prov.entradas;
+          Object.keys(prov.porAnio).forEach(anio => {
+            grupo.porAnio[anio] = (grupo.porAnio[anio] || 0) + prov.porAnio[anio];
+          });
+          grupo.proveedoresIndividuales.push({
+            nombre: prov.nombre,
+            medidas: prov.medidas,
+            kilos: prov.kilos,
+            porAnio: prov.porAnio
+          });
+        } else {
+          proveedoresIndividuales.push(prov);
+        }
+      });
+
+      return [
+        ...Object.values(grupos),
+        ...proveedoresIndividuales
+      ];
     },
     detalleEntradas() {
       if (!this.detalle) return [];

--- a/src/views/ReporteConsumoMedidas.vue
+++ b/src/views/ReporteConsumoMedidas.vue
@@ -103,7 +103,12 @@
             </thead>
             <tbody>
               <template v-for="prov in m.proveedores">
-                <tr class="fila-proveedor" :key="`${m.base}-${prov.nombre}`">
+                <tr
+                  class="fila-proveedor fila-clic"
+                  :key="`${m.base}-${prov.nombre}`"
+                  title="Clic para ver el desglose por fecha"
+                  @click="abrirDetalle({ titulo: `${m.base} · ${prov.nombre}`, proveedor: prov.nombre, base: m.base, esMaquila: false })"
+                >
                   <td class="col-nombre">{{ prov.nombre }}</td>
                   <td v-for="anio in reporte.anios" :key="anio" class="col-num">
                     {{ prov.porAnio[anio] ? formatNumber(prov.porAnio[anio], 0) : '—' }}
@@ -117,7 +122,9 @@
                 <tr
                   v-for="v in prov.variantes"
                   :key="`${m.base}-${prov.nombre}-${v.medida}`"
-                  class="fila-variante"
+                  class="fila-variante fila-clic"
+                  title="Clic para ver el desglose por fecha"
+                  @click="abrirDetalle({ titulo: `${v.medida} · ${prov.nombre}`, proveedor: prov.nombre, medidaExacta: v.medida, esMaquila: false })"
                 >
                   <td class="col-nombre variante-nombre">{{ v.medida }}</td>
                   <td v-for="anio in reporte.anios" :key="anio" class="col-num">
@@ -171,7 +178,13 @@
               </tr>
             </thead>
             <tbody>
-              <tr v-for="med in prov.medidas" :key="`prov-${prov.nombre}-${med.nombre}`">
+              <tr
+                v-for="med in prov.medidas"
+                :key="`prov-${prov.nombre}-${med.nombre}`"
+                class="fila-clic"
+                title="Clic para ver el desglose por fecha"
+                @click="abrirDetalle({ titulo: `${prov.nombre} · ${med.nombre}`, proveedor: prov.nombre, grupo: med.nombre, esMaquila: false })"
+              >
                 <td class="col-nombre">{{ med.nombre }}</td>
                 <td v-for="anio in reporte.anios" :key="anio" class="col-num">
                   {{ med.porAnio[anio] ? formatNumber(med.porAnio[anio], 0) : '—' }}
@@ -224,7 +237,13 @@
               </tr>
             </thead>
             <tbody>
-              <tr v-for="med in maq.medidas" :key="`maq-${maq.nombre}-${med.nombre}`">
+              <tr
+                v-for="med in maq.medidas"
+                :key="`maq-${maq.nombre}-${med.nombre}`"
+                class="fila-clic"
+                title="Clic para ver el desglose por fecha"
+                @click="abrirDetalle({ titulo: `${maq.nombre} (Maquila) · ${med.nombre}`, proveedor: maq.nombre, medidaExacta: med.nombre, esMaquila: true })"
+              >
                 <td class="col-nombre">{{ med.nombre }}</td>
                 <td v-for="anio in reporte.anios" :key="anio" class="col-num">
                   {{ med.porAnio[anio] ? formatNumber(med.porAnio[anio], 0) : '—' }}
@@ -263,7 +282,13 @@
             </tr>
           </thead>
           <tbody>
-            <tr v-for="item in reporte.sinClasificar" :key="`sc-${item.medida}-${item.proveedor}`">
+            <tr
+              v-for="item in reporte.sinClasificar"
+              :key="`sc-${item.medida}-${item.proveedor}`"
+              class="fila-clic"
+              title="Clic para ver el desglose por fecha"
+              @click="abrirDetalle({ titulo: `${item.medida} · ${item.proveedor}`, proveedor: item.proveedor, medidaExacta: item.medida, esMaquila: false })"
+            >
               <td class="col-nombre">{{ item.medida }}</td>
               <td class="col-nombre">{{ item.proveedor }}</td>
               <td class="col-num">{{ item.entradas }}</td>
@@ -273,6 +298,48 @@
         </table>
       </section>
     </template>
+
+    <!-- ============ MODAL DE DESGLOSE POR FECHA ============ -->
+    <div v-if="detalle" class="detalle-overlay no-print" @click.self="cerrarDetalle">
+      <div class="detalle-modal">
+        <div class="detalle-header">
+          <h3>{{ detalle.titulo }}</h3>
+          <button class="detalle-cerrar" @click="cerrarDetalle" title="Cerrar">&times;</button>
+        </div>
+        <p class="detalle-sub">
+          {{ detalleEntradas.length }} entradas
+          · <strong>{{ formatNumber(detalleKilos, 0) }} kg</strong>
+          <span v-if="detallePrecioPromedio"> · prom. ${{ formatNumber(detallePrecioPromedio) }}</span>
+          · {{ formatearFechaCorta(fechaDesde) }} — {{ formatearFechaCorta(fechaHasta) }}
+        </p>
+        <div class="detalle-tabla-wrap">
+          <table class="tabla">
+            <thead>
+              <tr>
+                <th class="col-nombre">Fecha</th>
+                <th class="col-nombre">Medida</th>
+                <th v-if="detalleTienePrecio" class="col-num">Precio</th>
+                <th class="col-num">Kilos</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="(e, idx) in detalleEntradas" :key="`det-${idx}`">
+                <td class="col-nombre">{{ formatearFechaDia(e.fecha) }}</td>
+                <td class="col-nombre">{{ e.medida }}</td>
+                <td v-if="detalleTienePrecio" class="col-num precio">
+                  {{ e.precio !== null && e.precio > 0 ? `$${formatNumber(e.precio)}` : '—' }}
+                </td>
+                <td class="col-num">{{ formatNumber(e.kilos, 0) }}</td>
+              </tr>
+              <tr class="fila-total">
+                <td class="col-nombre" :colspan="detalleTienePrecio ? 3 : 2">Total</td>
+                <td class="col-num">{{ formatNumber(detalleKilos, 0) }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -340,7 +407,8 @@ export default {
       fechaDesde: '2024-01-01',
       fechaHasta: fechaLocalISO(),
       busqueda: '',
-      mostrarPrecios: false
+      mostrarPrecios: false,
+      detalle: null
     };
   },
   computed: {
@@ -353,9 +421,14 @@ export default {
     esRangoTodo() {
       return this.fechaDesde === '2024-01-01' && this.fechaHasta === fechaLocalISO();
     },
+    rangoFechas() {
+      return {
+        desde: this.fechaDesde ? new Date(`${this.fechaDesde}T00:00:00`) : null,
+        hasta: this.fechaHasta ? new Date(`${this.fechaHasta}T23:59:59.999`) : null
+      };
+    },
     reporte() {
-      const desde = this.fechaDesde ? new Date(`${this.fechaDesde}T00:00:00`) : null;
-      const hasta = this.fechaHasta ? new Date(`${this.fechaHasta}T23:59:59.999`) : null;
+      const { desde, hasta } = this.rangoFechas;
 
       const r = {
         totalKilos: 0,
@@ -497,10 +570,48 @@ export default {
         maq.nombre.toLowerCase().includes(q) ||
         maq.medidas.some(med => med.nombre.toLowerCase().includes(q))
       );
+    },
+    detalleEntradas() {
+      if (!this.detalle) return [];
+      const d = this.detalle;
+      const { desde, hasta } = this.rangoFechas;
+      return this.entradas
+        .filter(e => {
+          if (desde && e.fecha < desde) return false;
+          if (hasta && e.fecha > hasta) return false;
+          if (d.esMaquila !== undefined && e.esMaquila !== d.esMaquila) return false;
+          if (d.proveedor && e.proveedor !== d.proveedor) return false;
+          if (d.medidaExacta && e.medida !== d.medidaExacta) return false;
+          if (d.base && baseDeMedida(e.medida) !== d.base) return false;
+          // "grupo" es la fila de la sección por proveedor: medida base, o la
+          // medida completa cuando no se pudo clasificar.
+          if (d.grupo && (baseDeMedida(e.medida) || e.medida) !== d.grupo) return false;
+          return true;
+        })
+        .sort((a, b) => a.fecha - b.fecha);
+    },
+    detalleKilos() {
+      return this.detalleEntradas.reduce((sum, e) => sum + e.kilos, 0);
+    },
+    detalleTienePrecio() {
+      return this.detalleEntradas.some(e => e.precio !== null && e.precio > 0);
+    },
+    detallePrecioPromedio() {
+      const conPrecio = this.detalleEntradas.filter(e => e.precio !== null && e.precio > 0);
+      const kilos = conPrecio.reduce((sum, e) => sum + e.kilos, 0);
+      if (kilos <= 0) return null;
+      return conPrecio.reduce((sum, e) => sum + e.precio * e.kilos, 0) / kilos;
     }
   },
   async mounted() {
+    this.onKeydown = (e) => {
+      if (e.key === 'Escape') this.cerrarDetalle();
+    };
+    document.addEventListener('keydown', this.onKeydown);
     await this.cargarEntradas();
+  },
+  beforeDestroy() {
+    document.removeEventListener('keydown', this.onKeydown);
   },
   methods: {
     formatNumber,
@@ -511,6 +622,16 @@ export default {
     },
     porcentaje(kilos) {
       return this.reporte.totalKilos > 0 ? (kilos / this.reporte.totalKilos) * 100 : 0;
+    },
+    formatearFechaDia(fecha) {
+      const d = fecha instanceof Date ? fecha : new Date(fecha);
+      return `${String(d.getDate()).padStart(2, '0')}/${String(d.getMonth() + 1).padStart(2, '0')}/${d.getFullYear()}`;
+    },
+    abrirDetalle(detalle) {
+      this.detalle = detalle;
+    },
+    cerrarDetalle() {
+      this.detalle = null;
     },
     seleccionarAnio(anio) {
       this.fechaDesde = `${anio}-01-01`;
@@ -865,6 +986,78 @@ th.col-num {
 .precio {
   color: #27ae60;
   font-weight: 600;
+}
+
+.fila-clic {
+  cursor: pointer;
+}
+
+.fila-clic:hover td {
+  background: #d6eaf8;
+}
+
+.detalle-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(20, 40, 60, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 16px;
+}
+
+.detalle-modal {
+  background: white;
+  border-radius: 10px;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.35);
+  width: min(680px, 100%);
+  max-height: 85vh;
+  display: flex;
+  flex-direction: column;
+  padding: 14px 18px 18px;
+}
+
+.detalle-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.detalle-header h3 {
+  margin: 0;
+  color: #1a5276;
+  font-size: 1.15rem;
+}
+
+.detalle-cerrar {
+  border: none;
+  background: transparent;
+  font-size: 1.6rem;
+  line-height: 1;
+  color: #6c7a89;
+  cursor: pointer;
+  padding: 2px 6px;
+}
+
+.detalle-cerrar:hover {
+  color: #c0392b;
+}
+
+.detalle-sub {
+  margin: 4px 0 10px;
+  font-size: 0.88rem;
+  color: #5d6d7e;
+}
+
+.detalle-tabla-wrap {
+  overflow-y: auto;
+}
+
+.detalle-tabla-wrap .tabla th {
+  position: sticky;
+  top: 0;
 }
 
 @media (max-width: 700px) {

--- a/src/views/ReporteConsumoMedidas.vue
+++ b/src/views/ReporteConsumoMedidas.vue
@@ -46,6 +46,20 @@
           Mostrar precio promedio
         </label>
         <button class="btn-imprimir" @click="imprimir">⎙ Imprimir</button>
+        <button
+          class="btn-pdf btn-pdf-detallado"
+          :disabled="!!generandoPdf || cargando || !!errorCarga"
+          @click="descargarPdf('detallado')"
+        >
+          {{ generandoPdf === 'detallado' ? 'Generando…' : '📊 PDF Detallado' }}
+        </button>
+        <button
+          class="btn-pdf btn-pdf-resumen"
+          :disabled="!!generandoPdf || cargando || !!errorCarga"
+          @click="descargarPdf('resumen')"
+        >
+          {{ generandoPdf === 'resumen' ? 'Generando…' : '📄 PDF Resumen' }}
+        </button>
       </div>
     </div>
 
@@ -447,7 +461,8 @@ export default {
       fechaHasta: fechaLocalISO(),
       busqueda: '',
       mostrarPrecios: false,
-      detalle: null
+      detalle: null,
+      generandoPdf: null
     };
   },
   computed: {
@@ -731,6 +746,39 @@ export default {
     imprimir() {
       window.print();
     },
+    async descargarPdf(tipo) {
+      if (this.generandoPdf || this.cargando) return;
+      this.generandoPdf = tipo;
+      try {
+        const modulo = await import(/* webpackChunkName: "pdf-reporte-consumo" */ '@/utils/pdf/reporteConsumo');
+        const q = this.busqueda.trim().toLowerCase();
+        const sinClasificar = q
+          ? this.reporte.sinClasificar.filter(item =>
+              item.medida.toLowerCase().includes(q) || item.proveedor.toLowerCase().includes(q)
+            )
+          : this.reporte.sinClasificar;
+        const datos = {
+          reporte: this.reporte,
+          medidas: this.medidasFiltradas,
+          sinClasificar,
+          proveedores: this.proveedoresAgrupados,
+          maquilas: this.maquilasFiltradas,
+          fechaDesde: this.fechaDesde,
+          fechaHasta: this.fechaHasta,
+          mostrarPrecios: this.mostrarPrecios
+        };
+        if (tipo === 'detallado') {
+          modulo.generarReporteConsumoDetalladoPDF(datos);
+        } else {
+          modulo.generarReporteConsumoResumenPDF(datos);
+        }
+      } catch (error) {
+        console.error('Error al generar el PDF del reporte de consumo:', error);
+        alert('No se pudo generar el PDF. Intenta de nuevo.');
+      } finally {
+        this.generandoPdf = null;
+      }
+    },
     async cargarEntradas() {
       this.cargando = true;
       this.errorCarga = null;
@@ -888,6 +936,47 @@ export default {
 
 .btn-imprimir:hover {
   background: #219653;
+}
+
+.btn-pdf {
+  padding: 7px 14px;
+  border: none;
+  border-radius: 5px;
+  color: white;
+  font-weight: 700;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  transition: transform 0.15s ease, box-shadow 0.2s ease;
+}
+
+.btn-pdf:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.btn-pdf:not(:disabled):hover {
+  transform: translateY(-1px);
+}
+
+.btn-pdf-detallado {
+  background: linear-gradient(90deg, #1a5276, #2980b9);
+  box-shadow: 0 2px 6px rgba(26, 82, 118, 0.35);
+}
+
+.btn-pdf-detallado:not(:disabled):hover {
+  box-shadow: 0 3px 10px rgba(26, 82, 118, 0.45);
+}
+
+.btn-pdf-resumen {
+  background: linear-gradient(90deg, #6c3483, #8e44ad);
+  box-shadow: 0 2px 6px rgba(108, 52, 131, 0.35);
+}
+
+.btn-pdf-resumen:not(:disabled):hover {
+  box-shadow: 0 3px 10px rgba(108, 52, 131, 0.45);
 }
 
 .estado-carga,

--- a/src/views/ReporteConsumoMedidas.vue
+++ b/src/views/ReporteConsumoMedidas.vue
@@ -427,8 +427,12 @@ function fechaLocalISO(date) {
 }
 
 function baseDeMedida(medida) {
-  const token = medidaDepurada(medida).split(/\s+/)[0];
-  return /\d/.test(token) ? token : null;
+  // Medidas con talla numérica se agrupan por la talla ("51/60 1ra Nacional"
+  // → tarjeta "51/60"). Las que no empiezan con número (Piojo, Mixta,
+  // Piojo Cristal…) usan su nombre depurado completo como grupo propio.
+  const depurada = medidaDepurada(medida);
+  const token = depurada.split(/\s+/)[0];
+  return /\d/.test(token) ? token : depurada;
 }
 
 function nuevoAcumulador(extra = {}) {
@@ -493,14 +497,12 @@ export default {
         anios: [],
         medidas: [],
         proveedores: [],
-        maquilas: [],
-        sinClasificar: []
+        maquilas: []
       };
 
       const medidas = {};
       const proveedores = {};
       const maquilas = {};
-      const sinClasificar = {};
       const anios = new Set();
 
       this.entradas.forEach(entrada => {
@@ -530,26 +532,16 @@ export default {
         r.porAnio[entrada.anio] = (r.porAnio[entrada.anio] || 0) + entrada.kilos;
 
         const base = baseDeMedida(medida);
-        const baseProveedor = base || medida;
 
         if (!proveedores[entrada.proveedor]) {
           proveedores[entrada.proveedor] = nuevoAcumulador({ nombre: entrada.proveedor, medidas: {} });
         }
         const prov = proveedores[entrada.proveedor];
         acumular(prov, entrada);
-        if (!prov.medidas[baseProveedor]) {
-          prov.medidas[baseProveedor] = nuevoAcumulador({ nombre: baseProveedor });
+        if (!prov.medidas[base]) {
+          prov.medidas[base] = nuevoAcumulador({ nombre: base });
         }
-        acumular(prov.medidas[baseProveedor], entrada);
-
-        if (!base) {
-          const clave = `${medida}||${entrada.proveedor}`;
-          if (!sinClasificar[clave]) {
-            sinClasificar[clave] = nuevoAcumulador({ medida, proveedor: entrada.proveedor });
-          }
-          acumular(sinClasificar[clave], entrada);
-          return;
-        }
+        acumular(prov.medidas[base], entrada);
 
         if (!medidas[base]) {
           medidas[base] = nuevoAcumulador({ base, proveedores: {} });
@@ -596,7 +588,6 @@ export default {
       r.maquilas = Object.values(maquilas)
         .map(maq => ({ ...maq, medidas: Object.values(maq.medidas).sort(porKilosDesc) }))
         .sort(porKilosDesc);
-      r.sinClasificar = Object.values(sinClasificar).sort(porKilosDesc);
 
       return r;
     },
@@ -679,9 +670,8 @@ export default {
           const medida = medidaDepurada(e.medida);
           if (d.medidaExacta && medida !== d.medidaExacta) return false;
           if (d.base && baseDeMedida(medida) !== d.base) return false;
-          // "grupo" es la fila de la sección por proveedor: medida base, o la
-          // medida completa cuando no se pudo clasificar.
-          if (d.grupo && (baseDeMedida(medida) || medida) !== d.grupo) return false;
+          // "grupo" es la fila de la sección por proveedor (la medida base).
+          if (d.grupo && baseDeMedida(medida) !== d.grupo) return false;
           return true;
         })
         .sort((a, b) => a.fecha - b.fecha);
@@ -751,16 +741,9 @@ export default {
       this.generandoPdf = tipo;
       try {
         const modulo = await import(/* webpackChunkName: "pdf-reporte-consumo" */ '@/utils/pdf/reporteConsumo');
-        const q = this.busqueda.trim().toLowerCase();
-        const sinClasificar = q
-          ? this.reporte.sinClasificar.filter(item =>
-              item.medida.toLowerCase().includes(q) || item.proveedor.toLowerCase().includes(q)
-            )
-          : this.reporte.sinClasificar;
         const datos = {
           reporte: this.reporte,
           medidas: this.medidasFiltradas,
-          sinClasificar,
           proveedores: this.proveedoresAgrupados,
           maquilas: this.maquilasFiltradas,
           fechaDesde: this.fechaDesde,


### PR DESCRIPTION
## Summary
Adds a new consumption report view (`ReporteConsumoMedidas`) that provides detailed historical analysis of product entries grouped by measure, supplier, and year. The report distinguishes between regular purchases and maquila (third-party processing) work, with optional price averaging and print support.

## Key Changes

- **New view: `ReporteConsumoMedidas.vue`** (909 lines)
  - Loads all entries from the `sacadas` collection and aggregates by measure base, supplier, and year
  - Three main report sections:
    - **Global by measure**: Groups entries by numeric measure prefix (e.g., "51/60"), with supplier and variant breakdowns
    - **By supplier**: Organizes data by supplier with measure distribution and percentage calculations
    - **Maquila**: Separate tracking for Ozuna and Joselito (third-party processing), excluded from main totals
  - Includes a "Measures to review" section for non-numeric medidas that don't fit standard grouping
  - Summary tiles showing total kilos, entry counts, and year-over-year comparisons
  - Date range filters with quick-select buttons (by year or full range from 2024–today)
  - Search/filter by measure or supplier name
  - Optional price averaging display (average $/kg per measure/supplier)
  - Print-friendly styling with `@media print` rules

- **Updated `Existencias.vue`**
  - Added "Consumo Histórico" button (📈) in header actions, linking to the new report

- **Updated `router.js`**
  - Added route `/reporte-consumo` → `ReporteConsumoMedidas` component (lazy-loaded)

## Implementation Details

- **Measure classification**: Uses `baseDeMedida()` to extract numeric prefix from medida strings; non-numeric entries are flagged for manual review via `DEPURACION_MEDIDAS` map
- **Maquila detection**: Entries from suppliers in `MAQUILAS` array or with `tipo === 'maquila'` are tracked separately and excluded from main consumption totals
- **Price averaging**: Accumulates weighted price sums (`precioSum / precioKilos`) for each grouping level; displayed only when checkbox enabled
- **Year aggregation**: Automatically detects available years from entry dates and builds `porAnio` breakdowns for each measure/supplier
- **Responsive design**: Flexbox layout with mobile-friendly table font sizing; print mode hides filters and optimizes spacing

https://claude.ai/code/session_01FzXmZxiqTyYc3mYNXBw52Q